### PR TITLE
Reorganized headers in (half of) the project.

### DIFF
--- a/include/solarus/DialogBoxSystem.h
+++ b/include/solarus/DialogBoxSystem.h
@@ -24,6 +24,8 @@
 #include "solarus/Dialog.h"
 #include "solarus/GameCommand.h"
 #include <list>
+#include <memory>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/Drawable.h
+++ b/include/solarus/Drawable.h
@@ -22,6 +22,7 @@
 #include "solarus/lowlevel/SurfacePtr.h"
 #include "solarus/lua/ExportableToLua.h"
 #include "solarus/lua/ScopedLuaRef.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/include/solarus/EntityData.h
+++ b/include/solarus/EntityData.h
@@ -22,6 +22,7 @@
 #include "solarus/entities/Layer.h"
 #include "solarus/lowlevel/Point.h"
 #include "solarus/lua/LuaData.h"
+#include <iosfwd>
 #include <map>
 #include <string>
 #include <vector>

--- a/include/solarus/Equipment.h
+++ b/include/solarus/Equipment.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -22,7 +22,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <vector>
 
 struct lua_State;
 

--- a/include/solarus/Game.h
+++ b/include/solarus/Game.h
@@ -25,6 +25,7 @@
 #include "solarus/KeysEffect.h"
 #include "solarus/Transition.h"
 #include <memory>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/Map.h
+++ b/include/solarus/Map.h
@@ -27,6 +27,8 @@
 #include "solarus/Camera.h"
 #include "solarus/MapData.h"
 #include "solarus/Transition.h"
+#include <memory>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/MapData.h
+++ b/include/solarus/MapData.h
@@ -22,6 +22,9 @@
 #include "solarus/EntityData.h"
 #include <array>
 #include <deque>
+#include <iosfwd>
+#include <map>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/QuestProperties.h
+++ b/include/solarus/QuestProperties.h
@@ -21,6 +21,7 @@
 #include "solarus/Common.h"
 #include "solarus/lowlevel/Size.h"
 #include "solarus/lua/LuaData.h"
+#include <iosfwd>
 #include <string>
 
 struct lua_State;

--- a/include/solarus/QuestResources.h
+++ b/include/solarus/QuestResources.h
@@ -20,6 +20,7 @@
 #include "solarus/Common.h"
 #include "solarus/lua/LuaData.h"
 #include "solarus/ResourceType.h"
+#include <iosfwd>
 #include <map>
 #include <string>
 

--- a/include/solarus/Savegame.h
+++ b/include/solarus/Savegame.h
@@ -20,6 +20,8 @@
 #include "solarus/Common.h"
 #include "solarus/Equipment.h"
 #include "solarus/lua/ExportableToLua.h"
+#include <map>
+#include <string>
 
 struct lua_State;
 

--- a/include/solarus/Sprite.h
+++ b/include/solarus/Sprite.h
@@ -21,6 +21,7 @@
 #include "solarus/Drawable.h"
 #include "solarus/SpritePtr.h"
 #include <map>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/SpriteAnimation.h
+++ b/include/solarus/SpriteAnimation.h
@@ -21,7 +21,6 @@
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lowlevel/SurfacePtr.h"
 #include "solarus/SpriteAnimationDirection.h"
-#include <memory>
 #include <string>
 #include <vector>
 

--- a/include/solarus/SpriteData.h
+++ b/include/solarus/SpriteData.h
@@ -20,9 +20,10 @@
 #include "solarus/Common.h"
 #include "solarus/lowlevel/Rectangle.h"
 #include "solarus/lua/LuaData.h"
+#include <deque>
+#include <iosfwd>
 #include <map>
 #include <string>
-#include <deque>
 #include <vector>
 
 namespace Solarus {

--- a/include/solarus/Timer.h
+++ b/include/solarus/Timer.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/lua/ExportableToLua.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/TransitionScrolling.h
+++ b/include/solarus/TransitionScrolling.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,7 +21,6 @@
 #include "solarus/lowlevel/Rectangle.h"
 #include "solarus/lowlevel/SurfacePtr.h"
 #include "solarus/Transition.h"
-#include <memory>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Hero.h
+++ b/include/solarus/entities/Hero.h
@@ -24,6 +24,8 @@
 #include "solarus/lowlevel/Point.h"
 #include "solarus/GameCommand.h"
 #include <list>
+#include <memory>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/lowlevel/Music.h
+++ b/include/solarus/lowlevel/Music.h
@@ -23,6 +23,7 @@
 #include "solarus/lowlevel/Sound.h"
 #include "solarus/lua/ScopedLuaRef.h"
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace Solarus {

--- a/include/solarus/movements/JumpMovement.h
+++ b/include/solarus/movements/JumpMovement.h
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/movements/PixelMovement.h"
+#include <string>
 
 namespace Solarus {
 

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -25,6 +25,9 @@
 #include "solarus/lowlevel/System.h"
 #include "solarus/lua/LuaContext.h"
 
+#include <algorithm>
+#include <list>
+
 namespace Solarus {
 
 /**

--- a/src/Drawable.cpp
+++ b/src/Drawable.cpp
@@ -20,6 +20,7 @@
 #include "solarus/lua/LuaContext.h"
 #include "solarus/lowlevel/Debug.h"
 #include <lua.hpp>
+#include <utility>
 
 namespace Solarus {
 

--- a/src/EntityData.cpp
+++ b/src/EntityData.cpp
@@ -19,6 +19,7 @@
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lua/LuaTools.h"
 #include <ostream>
+#include <utility>
 
 namespace Solarus {
 

--- a/src/Equipment.cpp
+++ b/src/Equipment.cpp
@@ -25,6 +25,7 @@
 #include "solarus/lowlevel/QuestFiles.h"
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lowlevel/Random.h"
+#include <algorithm>
 #include <sstream>
 
 namespace Solarus {

--- a/src/EquipmentItem.cpp
+++ b/src/EquipmentItem.cpp
@@ -21,6 +21,7 @@
 #include "solarus/Equipment.h"
 #include "solarus/Game.h"
 #include "solarus/Savegame.h"
+#include <algorithm>
 
 namespace Solarus {
 

--- a/src/EquipmentItemUsage.cpp
+++ b/src/EquipmentItemUsage.cpp
@@ -19,6 +19,7 @@
 #include "solarus/Equipment.h"
 #include "solarus/EquipmentItem.h"
 #include "solarus/lowlevel/Debug.h"
+#include <string>
 
 namespace Solarus {
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -36,7 +36,7 @@
 #include "solarus/Savegame.h"
 #include "solarus/Treasure.h"
 #include "solarus/TransitionFade.h"
-#include <vector>
+#include <map>
 
 namespace Solarus {
 

--- a/src/MainLoop.cpp
+++ b/src/MainLoop.cpp
@@ -31,6 +31,7 @@
 #include "solarus/CurrentQuest.h"
 #include <lua.hpp>
 #include <sstream>
+#include <string>
 
 namespace Solarus {
 

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -33,6 +33,7 @@
 #include "solarus/MapLoader.h"
 #include "solarus/Savegame.h"
 #include "solarus/Sprite.h"
+#include <list>
 
 namespace Solarus {
 

--- a/src/MapData.cpp
+++ b/src/MapData.cpp
@@ -18,7 +18,8 @@
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lua/LuaTools.h"
 #include "solarus/MapData.h"
-#include <fstream>
+#include <ostream>
+#include <utility>
 
 namespace Solarus {
 

--- a/src/MapLoader.cpp
+++ b/src/MapLoader.cpp
@@ -32,6 +32,8 @@
 #include "solarus/Map.h"
 #include "solarus/Game.h"
 #include "solarus/Camera.h"
+#include <memory>
+#include <string>
 
 namespace Solarus {
 

--- a/src/QuestProperties.cpp
+++ b/src/QuestProperties.cpp
@@ -21,8 +21,7 @@
 #include "solarus/lowlevel/Video.h"
 #include "solarus/lua/LuaTools.h"
 #include <lua.hpp>
-#include <sstream>
-#include <string>
+#include <ostream>
 
 namespace Solarus {
 

--- a/src/QuestResources.cpp
+++ b/src/QuestResources.cpp
@@ -18,8 +18,7 @@
 #include "solarus/lowlevel/QuestFiles.h"
 #include "solarus/lua/LuaTools.h"
 #include "solarus/QuestResources.h"
-#include <map>
-#include <fstream>
+#include <ostream>
 #include <sstream>
 
 namespace Solarus {

--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -28,6 +28,7 @@
 #include "solarus/lowlevel/Surface.h"
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lowlevel/Size.h"
+#include <memory>
 #include <sstream>
 
 namespace Solarus {

--- a/src/SpriteAnimationDirection.cpp
+++ b/src/SpriteAnimationDirection.cpp
@@ -18,6 +18,7 @@
 #include "solarus/lowlevel/PixelBits.h"
 #include "solarus/lowlevel/Surface.h"
 #include "solarus/lowlevel/Debug.h"
+#include <memory>
 #include <sstream>
 
 namespace Solarus {

--- a/src/SpriteAnimationSet.cpp
+++ b/src/SpriteAnimationSet.cpp
@@ -22,6 +22,9 @@
 #include "solarus/lowlevel/Rectangle.h"
 #include "solarus/lua/LuaTools.h"
 #include "solarus/SpriteData.h"
+#include <algorithm>
+#include <utility>
+#include <vector>
 
 namespace Solarus {
 

--- a/src/SpriteData.cpp
+++ b/src/SpriteData.cpp
@@ -17,8 +17,9 @@
 #include "solarus/SpriteData.h"
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lua/LuaTools.h"
-#include <fstream>
-#include <sstream>
+#include <algorithm>
+#include <ostream>
+#include <utility>
 
 namespace Solarus {
 

--- a/src/TransitionFade.cpp
+++ b/src/TransitionFade.cpp
@@ -20,6 +20,7 @@
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lowlevel/Color.h"
 #include "solarus/lowlevel/Video.h"
+#include <algorithm>
 
 namespace Solarus {
 

--- a/src/TransitionScrolling.cpp
+++ b/src/TransitionScrolling.cpp
@@ -22,6 +22,7 @@
 #include "solarus/lowlevel/Surface.h"
 #include "solarus/lowlevel/Video.h"
 #include "solarus/lowlevel/Debug.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/src/Treasure.cpp
+++ b/src/Treasure.cpp
@@ -24,6 +24,7 @@
 #include "solarus/lua/LuaContext.h"
 #include "solarus/lowlevel/Surface.h"
 #include "solarus/lowlevel/Debug.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/src/entities/Hero.cpp
+++ b/src/entities/Hero.cpp
@@ -62,6 +62,8 @@
 #include "solarus/EquipmentItem.h"
 #include "solarus/KeysEffect.h"
 #include "solarus/Sprite.h"
+#include <algorithm>
+#include <utility>
 
 namespace Solarus {
 

--- a/src/hero/HurtState.cpp
+++ b/src/hero/HurtState.cpp
@@ -24,6 +24,8 @@
 #include "solarus/lowlevel/System.h"
 #include "solarus/Game.h"
 #include "solarus/Equipment.h"
+#include <algorithm>
+#include <memory>
 
 namespace Solarus {
 

--- a/src/lowlevel/Music.cpp
+++ b/src/lowlevel/Music.cpp
@@ -21,8 +21,8 @@
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lua/LuaContext.h"
 #include <lua.hpp>
+#include <algorithm>
 #include <sstream>
-#include <vector>
 
 namespace Solarus {
 

--- a/src/lowlevel/PixelBits.cpp
+++ b/src/lowlevel/PixelBits.cpp
@@ -20,6 +20,7 @@
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lowlevel/System.h"
 #include <SDL.h>
+#include <algorithm>
 #include <iostream> // print functions
 
 namespace Solarus {

--- a/src/movements/JumpMovement.cpp
+++ b/src/movements/JumpMovement.cpp
@@ -17,6 +17,7 @@
 #include "solarus/movements/JumpMovement.h"
 #include "solarus/lua/LuaContext.h"
 #include "solarus/lowlevel/Debug.h"
+#include <algorithm>
 #include <sstream>
 
 namespace Solarus {


### PR DESCRIPTION
I reorganized the headers in roughly half of the projects. Here is what I did:
* Removed useless headers.
* Got rid of transitive includes of standard library components. This may avoid future problems (`std::min` and `std::max` were often used without including `<algorithm>` explicitly, that's not a given that it will be included by any other standard library header).

I may continue and apply the same changes to the rest of the project this weekend.