### PR TITLE
Reduced standard library transitive includes

### DIFF
--- a/include/solarus/entities/Block.h
+++ b/include/solarus/entities/Block.h
@@ -20,6 +20,7 @@
 #include "solarus/Common.h"
 #include "solarus/lowlevel/Point.h"
 #include "solarus/entities/Detector.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Bomb.h
+++ b/include/solarus/entities/Bomb.h
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/entities/Detector.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Boomerang.h
+++ b/include/solarus/entities/Boomerang.h
@@ -19,6 +19,8 @@
 
 #include "solarus/Common.h"
 #include "solarus/entities/MapEntity.h"
+#include <memory>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/CarriedItem.h
+++ b/include/solarus/entities/CarriedItem.h
@@ -20,6 +20,7 @@
 #include "solarus/Common.h"
 #include "solarus/entities/MapEntity.h"
 #include "solarus/SpritePtr.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Chest.h
+++ b/include/solarus/entities/Chest.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,6 +20,8 @@
 #include "solarus/Common.h"
 #include "solarus/Treasure.h"
 #include "solarus/entities/Detector.h"
+#include <map>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Crystal.h
+++ b/include/solarus/entities/Crystal.h
@@ -21,6 +21,7 @@
 #include "solarus/lowlevel/Point.h"
 #include "solarus/entities/Detector.h"
 #include <list>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/CrystalBlock.h
+++ b/include/solarus/entities/CrystalBlock.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/entities/Detector.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/CustomEntity.h
+++ b/include/solarus/entities/CustomEntity.h
@@ -21,6 +21,8 @@
 #include "solarus/entities/Detector.h"
 #include "solarus/lua/ScopedLuaRef.h"
 #include <map>
+#include <string>
+#include <vector>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Destination.h
+++ b/include/solarus/entities/Destination.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/entities/MapEntity.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Destructible.h
+++ b/include/solarus/entities/Destructible.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -21,6 +21,7 @@
 #include "solarus/entities/Detector.h"
 #include "solarus/entities/Ground.h"
 #include "solarus/Treasure.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Detector.h
+++ b/include/solarus/entities/Detector.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,6 +20,7 @@
 #include "solarus/Common.h"
 #include "solarus/entities/MapEntity.h"
 #include "solarus/entities/CollisionMode.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Door.h
+++ b/include/solarus/entities/Door.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,6 +19,8 @@
 
 #include "solarus/Common.h"
 #include "solarus/entities/Detector.h"
+#include <map>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/DynamicTile.h
+++ b/include/solarus/entities/DynamicTile.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/entities/MapEntity.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Enemy.h
+++ b/include/solarus/entities/Enemy.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -24,6 +24,8 @@
 #include "solarus/entities/EnemyReaction.h"
 #include "solarus/entities/Explosion.h"
 #include "solarus/entities/MapEntityPtr.h"
+#include <map>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/EnemyReaction.h
+++ b/include/solarus/entities/EnemyReaction.h
@@ -20,7 +20,6 @@
 #include "solarus/Common.h"
 #include <map>
 #include <string>
-#include <vector>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Explosion.h
+++ b/include/solarus/entities/Explosion.h
@@ -20,6 +20,7 @@
 #include "solarus/Common.h"
 #include "solarus/entities/Detector.h"
 #include <list>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Fire.h
+++ b/include/solarus/entities/Fire.h
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/entities/Detector.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Jumper.h
+++ b/include/solarus/entities/Jumper.h
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/entities/Detector.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Layer.h
+++ b/include/solarus/entities/Layer.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */

--- a/include/solarus/entities/MapEntities.h
+++ b/include/solarus/entities/MapEntities.h
@@ -24,10 +24,11 @@
 #include "solarus/entities/MapEntityPtr.h"
 #include "solarus/entities/TilePtr.h"
 #include "solarus/Transition.h"
-#include <vector>
 #include <list>
 #include <map>
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace Solarus {
 

--- a/include/solarus/entities/MapEntity.h
+++ b/include/solarus/entities/MapEntity.h
@@ -27,6 +27,8 @@
 #include "solarus/entities/EnemyReaction.h"
 #include "solarus/lowlevel/Rectangle.h"
 #include "solarus/SpritePtr.h"
+#include <memory>
+#include <string>
 #include <vector>
 
 struct lua_State;

--- a/include/solarus/entities/Npc.h
+++ b/include/solarus/entities/Npc.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,6 +20,7 @@
 #include "solarus/Common.h"
 #include "solarus/entities/Detector.h"
 #include "solarus/KeysEffect.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Pickable.h
+++ b/include/solarus/entities/Pickable.h
@@ -24,6 +24,8 @@
 #include "solarus/movements/FallingHeight.h"
 #include "solarus/SpritePtr.h"
 #include "solarus/Treasure.h"
+#include <memory>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Sensor.h
+++ b/include/solarus/entities/Sensor.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/entities/Detector.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Separator.h
+++ b/include/solarus/entities/Separator.h
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/entities/Detector.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/ShopTreasure.h
+++ b/include/solarus/entities/ShopTreasure.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -22,6 +22,8 @@
 #include "solarus/Sprite.h"
 #include "solarus/entities/Detector.h"
 #include "solarus/lowlevel/TextSurface.h"
+#include <memory>
+#include <string>
 
 struct lua_State;
 

--- a/include/solarus/entities/Stairs.h
+++ b/include/solarus/entities/Stairs.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/entities/Detector.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Stream.h
+++ b/include/solarus/entities/Stream.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/entities/Detector.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/StreamAction.h
+++ b/include/solarus/entities/StreamAction.h
@@ -21,6 +21,7 @@
 #include "solarus/entities/MapEntityPtr.h"
 #include "solarus/lowlevel/Point.h"
 #include <cstdint>
+#include <memory>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Switch.h
+++ b/include/solarus/entities/Switch.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,6 +19,8 @@
 
 #include "solarus/Common.h"
 #include "solarus/entities/Detector.h"
+#include <map>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Teletransporter.h
+++ b/include/solarus/entities/Teletransporter.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,6 +20,7 @@
 #include "solarus/Common.h"
 #include "solarus/entities/Detector.h"
 #include "solarus/Transition.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Tile.h
+++ b/include/solarus/entities/Tile.h
@@ -20,6 +20,7 @@
 #include "solarus/Common.h"
 #include "solarus/entities/MapEntity.h"
 #include "solarus/lowlevel/SurfacePtr.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/entities/TilesetData.h
+++ b/include/solarus/entities/TilesetData.h
@@ -23,6 +23,7 @@
 #include "solarus/lowlevel/Color.h"
 #include "solarus/lowlevel/Rectangle.h"
 #include "solarus/lua/LuaData.h"
+#include <iosfwd>
 #include <map>
 #include <string>
 #include <vector>

--- a/include/solarus/entities/TimeScrollingTilePattern.h
+++ b/include/solarus/entities/TimeScrollingTilePattern.h
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/entities/SimpleTilePattern.h"
+#include <cstdint>
 
 namespace Solarus {
 

--- a/include/solarus/entities/Wall.h
+++ b/include/solarus/entities/Wall.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,6 +20,7 @@
 #include "solarus/Common.h"
 #include "solarus/entities/MapEntity.h"
 #include <set>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/hero/BackToSolidGroundState.h
+++ b/include/solarus/hero/BackToSolidGroundState.h
@@ -19,6 +19,7 @@
 
 #include "solarus/lowlevel/Point.h"
 #include "solarus/hero/State.h"
+#include <cstdint>
 
 namespace Solarus {
 

--- a/include/solarus/hero/BoomerangState.h
+++ b/include/solarus/hero/BoomerangState.h
@@ -18,6 +18,7 @@
 #define SOLARUS_HERO_BOOMERANG_STATE_H
 
 #include "solarus/hero/State.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/hero/CarryingState.h
+++ b/include/solarus/hero/CarryingState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -18,6 +18,7 @@
 #define SOLARUS_HERO_CARRYING_STATE_H
 
 #include "solarus/hero/PlayerMovementState.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/include/solarus/hero/ForcedWalkingState.h
+++ b/include/solarus/hero/ForcedWalkingState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -18,6 +18,8 @@
 #define SOLARUS_HERO_FORCED_WALKING_STATE_H
 
 #include "solarus/hero/State.h"
+#include <memory>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/hero/FreeState.h
+++ b/include/solarus/hero/FreeState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,6 +19,7 @@
 
 #include "solarus/hero/State.h"
 #include "solarus/hero/PlayerMovementState.h"
+#include <cstdint>
 
 namespace Solarus {
 

--- a/include/solarus/hero/HookshotState.h
+++ b/include/solarus/hero/HookshotState.h
@@ -18,6 +18,7 @@
 #define SOLARUS_HERO_HOOKSHOT_STATE_H
 
 #include "solarus/hero/State.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/include/solarus/hero/HurtState.h
+++ b/include/solarus/hero/HurtState.h
@@ -18,6 +18,7 @@
 #define SOLARUS_HERO_HURT_STATE_H
 
 #include "solarus/hero/State.h"
+#include <cstdint>
 
 namespace Solarus {
 

--- a/include/solarus/hero/JumpingState.h
+++ b/include/solarus/hero/JumpingState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -18,6 +18,7 @@
 #define SOLARUS_HERO_JUMPING_STATE_H
 
 #include "solarus/hero/State.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/include/solarus/hero/LiftingState.h
+++ b/include/solarus/hero/LiftingState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -18,6 +18,7 @@
 #define SOLARUS_HERO_LIFTING_STATE_H
 
 #include "solarus/hero/State.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/include/solarus/hero/PlayerMovementState.h
+++ b/include/solarus/hero/PlayerMovementState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,6 +19,9 @@
 
 #include "solarus/Common.h"
 #include "solarus/hero/State.h"
+#include <cstdint>
+#include <memory>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/hero/PullingState.h
+++ b/include/solarus/hero/PullingState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -18,6 +18,7 @@
 #define SOLARUS_HERO_PULLING_STATE_H
 
 #include "solarus/hero/State.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/include/solarus/hero/PushingState.h
+++ b/include/solarus/hero/PushingState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -18,6 +18,7 @@
 #define SOLARUS_HERO_PUSHING_STATE_H
 
 #include "solarus/hero/State.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/include/solarus/hero/RunningState.h
+++ b/include/solarus/hero/RunningState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -18,6 +18,7 @@
 #define SOLARUS_HERO_RUNNING_STATE_H
 
 #include "solarus/hero/State.h"
+#include <cstdint>
 
 namespace Solarus {
 

--- a/include/solarus/hero/StairsState.h
+++ b/include/solarus/hero/StairsState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,6 +19,8 @@
 
 #include "solarus/hero/State.h"
 #include "solarus/entities/Stairs.h"
+#include <cstdint>
+#include <memory>
 
 namespace Solarus {
 

--- a/include/solarus/hero/State.h
+++ b/include/solarus/hero/State.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,6 +20,9 @@
 #include "solarus/Common.h"
 #include "solarus/entities/CarriedItem.h"
 #include "solarus/entities/Hero.h"
+#include <cstdint>
+#include <memory>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/hero/SwimmingState.h
+++ b/include/solarus/hero/SwimmingState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -18,6 +18,7 @@
 #define SOLARUS_HERO_SWIMMING_STATE_H
 
 #include "solarus/hero/PlayerMovementState.h"
+#include <cstdint>
 
 namespace Solarus {
 

--- a/include/solarus/hero/SwordLoadingState.h
+++ b/include/solarus/hero/SwordLoadingState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -18,6 +18,7 @@
 #define SOLARUS_HERO_SWORD_LOADING_STATE_H
 
 #include "solarus/hero/PlayerMovementState.h"
+#include <cstdint>
 
 namespace Solarus {
 

--- a/include/solarus/hero/SwordTappingState.h
+++ b/include/solarus/hero/SwordTappingState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -18,6 +18,7 @@
 #define SOLARUS_HERO_SWORD_TAPPING_STATE_H
 
 #include "solarus/hero/State.h"
+#include <cstdint>
 
 namespace Solarus {
 

--- a/include/solarus/hero/VictoryState.h
+++ b/include/solarus/hero/VictoryState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -18,6 +18,7 @@
 #define SOLARUS_HERO_VICTORY_STATE_H
 
 #include "solarus/hero/State.h"
+#include <cstdint>
 
 namespace Solarus {
 

--- a/include/solarus/lowlevel/FontResource.h
+++ b/include/solarus/lowlevel/FontResource.h
@@ -20,6 +20,7 @@
 #include "solarus/Common.h"
 #include "solarus/lowlevel/SurfacePtr.h"
 #include <map>
+#include <memory>
 #include <string>
 #include <SDL_ttf.h>
 

--- a/include/solarus/lowlevel/Hq2xFilter.h
+++ b/include/solarus/lowlevel/Hq2xFilter.h
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/lowlevel/PixelFilter.h"
+#include <cstdint>
 
 namespace Solarus {
 

--- a/include/solarus/lowlevel/Hq3xFilter.h
+++ b/include/solarus/lowlevel/Hq3xFilter.h
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/lowlevel/PixelFilter.h"
+#include <cstdint>
 
 namespace Solarus {
 

--- a/include/solarus/lowlevel/Hq4xFilter.h
+++ b/include/solarus/lowlevel/Hq4xFilter.h
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/lowlevel/PixelFilter.h"
+#include <cstdint>
 
 namespace Solarus {
 

--- a/include/solarus/lowlevel/ItDecoder.h
+++ b/include/solarus/lowlevel/ItDecoder.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,6 +20,7 @@
 #include "solarus/Common.h"
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <modplug.h>
 
 namespace Solarus {

--- a/include/solarus/lowlevel/Scale2xFilter.h
+++ b/include/solarus/lowlevel/Scale2xFilter.h
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/lowlevel/PixelFilter.h"
+#include <cstdint>
 
 namespace Solarus {
 

--- a/include/solarus/lowlevel/Surface.h
+++ b/include/solarus/lowlevel/Surface.h
@@ -23,6 +23,9 @@
 #include "solarus/Drawable.h"
 #include <SDL.h>
 #include <SDL_image.h>
+#include <cstdint>
+#include <memory>
+#include <string>
 #include <vector>
 
 namespace Solarus {

--- a/include/solarus/lowlevel/TextSurface.h
+++ b/include/solarus/lowlevel/TextSurface.h
@@ -22,6 +22,7 @@
 #include "solarus/lowlevel/Point.h"
 #include "solarus/Drawable.h"
 #include <map>
+#include <string>
 #include <SDL_ttf.h>
 
 namespace Solarus {

--- a/include/solarus/lowlevel/shaders/GL_2DShader.h
+++ b/include/solarus/lowlevel/shaders/GL_2DShader.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -24,6 +24,7 @@
 #include "solarus/lowlevel/shaders/Shader.h"
 #include <SDL.h>
 #include <SDL_opengl.h>
+#include <string>
 
 
 namespace Solarus {

--- a/include/solarus/lowlevel/shaders/GL_ARBShader.h
+++ b/include/solarus/lowlevel/shaders/GL_ARBShader.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -24,6 +24,7 @@
 #include "solarus/lowlevel/shaders/Shader.h"
 #include <SDL.h>
 #include <SDL_opengl.h>
+#include <string>
 
 
 namespace Solarus {

--- a/include/solarus/lowlevel/shaders/Shader.h
+++ b/include/solarus/lowlevel/shaders/Shader.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -22,6 +22,7 @@
 #include "solarus/lowlevel/SurfacePtr.h"
 #include "solarus/lua/LuaContext.h"
 #include "solarus/lua/LuaTools.h"
+#include <string>
 
 namespace Solarus {
 
@@ -31,14 +32,14 @@ namespace Solarus {
 class Shader {
 
   public:
-  
+
     Shader(const std::string& shader_name);
     virtual ~Shader();
 
     static void set_shading_language_version(const std::string& version);
     static const std::string& get_sampler_type();
     static void reset_time();
-  
+
     const std::string& get_name();
     double get_default_window_scale();
     bool is_valid();

--- a/include/solarus/lowlevel/shaders/ShaderContext.h
+++ b/include/solarus/lowlevel/shaders/ShaderContext.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -19,6 +19,8 @@
 
 #include "solarus/Common.h"
 #include "solarus/lowlevel/shaders/Shader.h"
+#include <memory>
+#include <string>
 
 namespace Solarus {
 
@@ -30,13 +32,13 @@ namespace Solarus {
 class ShaderContext {
 
   public:
-  
+
     static bool initialize();
     static void quit();
     static std::unique_ptr<Shader> create_shader(const std::string& shader_name);
 
   private:
-  
+
     static bool shader_supported;
 };
 

--- a/include/solarus/lua/LuaContext.h
+++ b/include/solarus/lua/LuaContext.h
@@ -32,9 +32,11 @@
 #include "solarus/Ability.h"
 #include "solarus/SpritePtr.h"
 #include "solarus/TimerPtr.h"
-#include <map>
-#include <set>
 #include <list>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
 
 struct lua_State;
 struct luaL_Reg;

--- a/include/solarus/lua/LuaTools.h
+++ b/include/solarus/lua/LuaTools.h
@@ -22,9 +22,8 @@
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lua/LuaException.h"
 #include "solarus/SolarusFatal.h"
-#include <string>
 #include <map>
-#include <vector>
+#include <string>
 #include <lua.hpp>
 
 namespace Solarus {

--- a/include/solarus/movements/CircleMovement.h
+++ b/include/solarus/movements/CircleMovement.h
@@ -20,6 +20,8 @@
 #include "solarus/Common.h"
 #include "solarus/entities/MapEntityPtr.h"
 #include "solarus/movements/Movement.h"
+#include <cstdint>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/movements/Movement.h
+++ b/include/solarus/movements/Movement.h
@@ -21,6 +21,8 @@
 #include "solarus/lowlevel/Rectangle.h"
 #include "solarus/lua/ExportableToLua.h"
 #include "solarus/lua/ScopedLuaRef.h"
+#include <cstdint>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/movements/PathFinding.h
+++ b/include/solarus/movements/PathFinding.h
@@ -21,6 +21,7 @@
 #include "solarus/lowlevel/Point.h"
 #include <list>
 #include <map>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/movements/PathFindingMovement.h
+++ b/include/solarus/movements/PathFindingMovement.h
@@ -20,6 +20,8 @@
 #include "solarus/Common.h"
 #include "solarus/entities/MapEntityPtr.h"
 #include "solarus/movements/PathMovement.h"
+#include <cstdint>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/movements/PathMovement.h
+++ b/include/solarus/movements/PathMovement.h
@@ -19,6 +19,8 @@
 
 #include "solarus/Common.h"
 #include "solarus/movements/PixelMovement.h"
+#include <cstdint>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/movements/PixelMovement.h
+++ b/include/solarus/movements/PixelMovement.h
@@ -20,7 +20,9 @@
 #include "solarus/Common.h"
 #include "solarus/movements/Movement.h"
 #include "solarus/lowlevel/Point.h"
+#include <cstdint>
 #include <list>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/movements/RandomMovement.h
+++ b/include/solarus/movements/RandomMovement.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,6 +20,8 @@
 #include "solarus/Common.h"
 #include "solarus/movements/StraightMovement.h"
 #include "solarus/lowlevel/Rectangle.h"
+#include <cstdint>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/movements/RandomPathMovement.h
+++ b/include/solarus/movements/RandomPathMovement.h
@@ -19,6 +19,7 @@
 
 #include "solarus/Common.h"
 #include "solarus/movements/PathMovement.h"
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/movements/StraightMovement.h
+++ b/include/solarus/movements/StraightMovement.h
@@ -20,6 +20,8 @@
 #include "solarus/Common.h"
 #include "solarus/lowlevel/Point.h"
 #include "solarus/movements/Movement.h"
+#include <cstdint>
+#include <string>
 
 namespace Solarus {
 

--- a/include/solarus/movements/TargetMovement.h
+++ b/include/solarus/movements/TargetMovement.h
@@ -21,6 +21,8 @@
 #include "solarus/entities/MapEntityPtr.h"
 #include "solarus/lowlevel/Point.h"
 #include "solarus/movements/StraightMovement.h"
+#include <cstdint>
+#include <string>
 
 namespace Solarus {
 

--- a/src/entities/Arrow.cpp
+++ b/src/entities/Arrow.cpp
@@ -30,6 +30,8 @@
 #include "solarus/lowlevel/Sound.h"
 #include "solarus/lowlevel/System.h"
 #include "solarus/lowlevel/Debug.h"
+#include <memory>
+#include <string>
 
 namespace Solarus {
 

--- a/src/entities/Block.cpp
+++ b/src/entities/Block.cpp
@@ -27,6 +27,7 @@
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lowlevel/Sound.h"
 #include "solarus/lua/LuaContext.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/src/entities/Bomb.cpp
+++ b/src/entities/Bomb.cpp
@@ -26,6 +26,7 @@
 #include "solarus/Sprite.h"
 #include "solarus/Map.h"
 #include "solarus/KeysEffect.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/src/entities/CarriedItem.cpp
+++ b/src/entities/CarriedItem.cpp
@@ -34,6 +34,7 @@
 #include "solarus/lowlevel/System.h"
 #include "solarus/lowlevel/Sound.h"
 #include "solarus/lowlevel/Geometry.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/src/entities/Crystal.cpp
+++ b/src/entities/Crystal.cpp
@@ -26,6 +26,7 @@
 #include "solarus/Sprite.h"
 #include "solarus/SpriteAnimationSet.h"
 #include <lua.hpp>
+#include <memory>
 
 namespace Solarus {
 

--- a/src/entities/Destructible.cpp
+++ b/src/entities/Destructible.cpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -34,6 +34,7 @@
 #include "solarus/Map.h"
 #include "solarus/Sprite.h"
 #include <lauxlib.h>
+#include <memory>
 
 namespace Solarus {
 

--- a/src/entities/Enemy.cpp
+++ b/src/entities/Enemy.cpp
@@ -38,6 +38,7 @@
 #include "solarus/lowlevel/System.h"
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lowlevel/Sound.h"
+#include <memory>
 #include <sstream>
 
 namespace Solarus {

--- a/src/entities/EnemyReaction.cpp
+++ b/src/entities/EnemyReaction.cpp
@@ -17,7 +17,6 @@
 #include "solarus/entities/EnemyReaction.h"
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/Sprite.h"
-#include <sstream>
 
 namespace Solarus {
 

--- a/src/entities/Hookshot.cpp
+++ b/src/entities/Hookshot.cpp
@@ -30,6 +30,8 @@
 #include "solarus/entities/Hero.h"
 #include "solarus/entities/Stairs.h"
 #include "solarus/Map.h"
+#include <memory>
+#include <string>
 
 namespace Solarus {
 

--- a/src/entities/MapEntity.cpp
+++ b/src/entities/MapEntity.cpp
@@ -32,6 +32,8 @@
 #include "solarus/Map.h"
 #include "solarus/Sprite.h"
 #include "solarus/SpriteAnimationSet.h"
+#include <list>
+#include <utility>
 
 namespace Solarus {
 

--- a/src/entities/Npc.cpp
+++ b/src/entities/Npc.cpp
@@ -29,6 +29,7 @@
 #include "solarus/Map.h"
 #include "solarus/Sprite.h"
 #include <lua.hpp>
+#include <memory>
 
 namespace Solarus {
 

--- a/src/entities/SelfScrollingTilePattern.cpp
+++ b/src/entities/SelfScrollingTilePattern.cpp
@@ -48,57 +48,56 @@ void SelfScrollingTilePattern::draw(
   Point dst = dst_position;
 
   // draw the tile with an offset that depends on its position modulo its size
-  int offset_x, offset_y;
+  Point offset;
 
   if (dst.x >= 0) {
-    offset_x = dst.x % src.get_width();
+    offset.x = dst.x % src.get_width();
   }
   else { // the modulo operation does not like negative numbers
-    offset_x = src.get_width() - (-dst.x % src.get_width());
+    offset.x = src.get_width() - (-dst.x % src.get_width());
   }
 
   if (dst.y >= 0) {
-    offset_y = dst.y % src.get_height();
+    offset.y = dst.y % src.get_height();
   }
   else {
-    offset_y = src.get_height() - (-dst.y % src.get_height());
+    offset.y = src.get_height() - (-dst.y % src.get_height());
   }
 
   // apply a scrolling ratio
-  offset_x /= 2;
-  offset_y /= 2;
+  offset /= 2;
 
   // draw the pattern in four steps
   const SurfacePtr& tileset_image = tileset.get_tiles_image();
 
-  src.add_x(offset_x);
-  src.add_width(-offset_x);
-  src.add_y(offset_y);
-  src.add_height(-offset_y);
+  src.add_x(offset.x);
+  src.add_width(-offset.x);
+  src.add_y(offset.y);
+  src.add_height(-offset.y);
   tileset_image->draw_region(src, dst_surface, dst);
 
   src = position_in_tileset;
   dst = dst_position;
-  src.add_y(offset_y);
-  src.add_height(-offset_y);
-  dst.x += src.get_width() - offset_x;
-  src.set_width(offset_x);
+  src.add_y(offset.y);
+  src.add_height(-offset.y);
+  dst.x += src.get_width() - offset.x;
+  src.set_width(offset.x);
   tileset_image->draw_region(src, dst_surface, dst);
 
   src = position_in_tileset;
   dst = dst_position;
-  src.add_x(offset_x);
-  src.add_width(-offset_x);
-  dst.y += src.get_height() - offset_y;
-  src.set_height(offset_y);
+  src.add_x(offset.x);
+  src.add_width(-offset.x);
+  dst.y += src.get_height() - offset.y;
+  src.set_height(offset.y);
   tileset_image->draw_region(src, dst_surface, dst);
 
   src = position_in_tileset;
   dst = dst_position;
-  dst.x += src.get_width() - offset_x;
-  src.set_width(offset_x);
-  dst.y += src.get_height() - offset_y;
-  src.set_height(offset_y);
+  dst.x += src.get_width() - offset.x;
+  src.set_width(offset.x);
+  dst.y += src.get_height() - offset.y;
+  src.set_height(offset.y);
   tileset_image->draw_region(src, dst_surface, dst);
 }
 

--- a/src/entities/Stairs.cpp
+++ b/src/entities/Stairs.cpp
@@ -22,6 +22,7 @@
 #include "solarus/lowlevel/Sound.h"
 #include "solarus/Game.h"
 #include "solarus/Map.h"
+#include <list>
 
 namespace Solarus {
 

--- a/src/entities/Stream.cpp
+++ b/src/entities/Stream.cpp
@@ -19,6 +19,7 @@
 #include "solarus/Map.h"
 #include "solarus/Sprite.h"
 #include "solarus/lowlevel/QuestFiles.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/src/entities/Tileset.cpp
+++ b/src/entities/Tileset.cpp
@@ -28,6 +28,8 @@
 #include "solarus/lua/LuaTools.h"
 #include <lua.hpp>
 #include <sstream>
+#include <utility>
+#include <vector>
 
 namespace Solarus {
 

--- a/src/entities/TilesetData.cpp
+++ b/src/entities/TilesetData.cpp
@@ -18,8 +18,9 @@
 #include "solarus/entities/TilesetData.h"
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lua/LuaTools.h"
-#include <fstream>
+#include <ostream>
 #include <sstream>
+#include <utility>
 
 namespace Solarus {
 

--- a/src/entities/TimeScrollingTilePattern.cpp
+++ b/src/entities/TimeScrollingTilePattern.cpp
@@ -68,39 +68,39 @@ void TimeScrollingTilePattern::draw(
   Rectangle src = position_in_tileset;
   Point dst = dst_position;
 
-  int offset_x, offset_y; // draw the tile with an offset that depends on the time
+  Point offset; // draw the tile with an offset that depends on the time
 
-  offset_x = src.get_width() - (shift % src.get_width());
-  offset_y = shift % src.get_height();
+  offset.x = src.get_width() - (shift % src.get_width());
+  offset.y = shift % src.get_height();
 
-  src.add_x(offset_x);
-  src.add_width(-offset_x);
-  src.add_y(offset_y);
-  src.add_height(-offset_y);
+  src.add_x(offset.x);
+  src.add_width(-offset.x);
+  src.add_y(offset.y);
+  src.add_height(-offset.y);
   tileset.get_tiles_image()->draw_region(src, dst_surface, dst);
 
   src = position_in_tileset;
   dst = dst_position;
-  src.add_y(offset_y);
-  src.add_height(-offset_y);
-  dst.x += src.get_width() - offset_x;
-  src.set_width(offset_x);
+  src.add_y(offset.y);
+  src.add_height(-offset.y);
+  dst.x += src.get_width() - offset.x;
+  src.set_width(offset.x);
   tileset.get_tiles_image()->draw_region(src, dst_surface, dst);
 
   src = position_in_tileset;
   dst = dst_position;
-  src.add_x(offset_x);
-  src.add_width(-offset_x);
-  dst.y += src.get_height() - offset_y;
-  src.set_height(offset_y);
+  src.add_x(offset.x);
+  src.add_width(-offset.x);
+  dst.y += src.get_height() - offset.y;
+  src.set_height(offset.y);
   tileset.get_tiles_image()->draw_region(src, dst_surface, dst);
 
   src = position_in_tileset;
   dst = dst_position;
-  dst.x += src.get_width() - offset_x;
-  src.set_width(offset_x);
-  dst.y += src.get_height() - offset_y;
-  src.set_height(offset_y);
+  dst.x += src.get_width() - offset.x;
+  src.set_width(offset.x);
+  dst.y += src.get_height() - offset.y;
+  src.set_height(offset.y);
   tileset.get_tiles_image()->draw_region(src, dst_surface, dst);
 }
 

--- a/src/hero/BackToSolidGroundState.cpp
+++ b/src/hero/BackToSolidGroundState.cpp
@@ -22,6 +22,7 @@
 #include "solarus/lowlevel/System.h"
 #include "solarus/lowlevel/Sound.h"
 #include "solarus/Map.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/src/hero/BoomerangState.cpp
+++ b/src/hero/BoomerangState.cpp
@@ -23,6 +23,7 @@
 #include "solarus/Game.h"
 #include "solarus/GameCommands.h"
 #include "solarus/Map.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/src/hero/BowState.cpp
+++ b/src/hero/BowState.cpp
@@ -20,6 +20,7 @@
 #include "solarus/entities/MapEntities.h"
 #include "solarus/entities/Arrow.h"
 #include "solarus/lowlevel/Sound.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/src/hero/PullingState.cpp
+++ b/src/hero/PullingState.cpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -22,6 +22,7 @@
 #include "solarus/movements/PathMovement.h"
 #include "solarus/Game.h"
 #include "solarus/GameCommands.h"
+#include <string>
 
 namespace Solarus {
 

--- a/src/hero/PushingState.cpp
+++ b/src/hero/PushingState.cpp
@@ -22,6 +22,7 @@
 #include "solarus/movements/PathMovement.h"
 #include "solarus/Game.h"
 #include "solarus/GameCommands.h"
+#include <string>
 
 namespace Solarus {
 

--- a/src/hero/RunningState.cpp
+++ b/src/hero/RunningState.cpp
@@ -29,6 +29,7 @@
 #include "solarus/GameCommands.h"
 #include "solarus/Map.h"
 #include "solarus/Equipment.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/src/hero/SpinAttackState.cpp
+++ b/src/hero/SpinAttackState.cpp
@@ -25,7 +25,9 @@
 #include "solarus/movements/StraightMovement.h"
 #include "solarus/Equipment.h"
 #include "solarus/Game.h"
+#include <memory>
 #include <sstream>
+#include <string>
 
 namespace Solarus {
 

--- a/src/hero/StairsState.cpp
+++ b/src/hero/StairsState.cpp
@@ -27,6 +27,7 @@
 #include "solarus/Map.h"
 #include "solarus/KeysEffect.h"
 #include "solarus/lowlevel/Debug.h"
+#include <string>
 
 namespace Solarus {
 

--- a/src/hero/SwordLoadingState.cpp
+++ b/src/hero/SwordLoadingState.cpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -28,6 +28,7 @@
 #include "solarus/Game.h"
 #include "solarus/GameCommands.h"
 #include <sstream>
+#include <string>
 
 namespace Solarus {
 

--- a/src/hero/SwordSwingingState.cpp
+++ b/src/hero/SwordSwingingState.cpp
@@ -23,6 +23,7 @@
 #include "solarus/Equipment.h"
 #include "solarus/Game.h"
 #include "solarus/GameCommands.h"
+#include <memory>
 
 namespace Solarus {
 

--- a/src/hero/SwordTappingState.cpp
+++ b/src/hero/SwordTappingState.cpp
@@ -26,6 +26,8 @@
 #include "solarus/Game.h"
 #include "solarus/GameCommands.h"
 #include "solarus/Map.h"
+#include <memory>
+#include <string>
 
 namespace Solarus {
 

--- a/src/hero/TreasureState.cpp
+++ b/src/hero/TreasureState.cpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,6 +23,7 @@
 #include "solarus/Game.h"
 #include "solarus/Map.h"
 #include <lua.hpp>
+#include <string>
 
 namespace Solarus {
 

--- a/src/lowlevel/Debug.cpp
+++ b/src/lowlevel/Debug.cpp
@@ -19,7 +19,6 @@
 #include <cstdlib>  // std::abort
 #include <fstream>
 #include <iostream>
-#include <string>
 #include <SDL_messagebox.h>
 
 namespace Solarus {

--- a/src/lowlevel/FontResource.cpp
+++ b/src/lowlevel/FontResource.cpp
@@ -19,6 +19,7 @@
 #include "solarus/lowlevel/FontResource.h"
 #include "solarus/lowlevel/Surface.h"
 #include "solarus/CurrentQuest.h"
+#include <utility>
 
 namespace Solarus {
 

--- a/src/lowlevel/PixelBits.cpp
+++ b/src/lowlevel/PixelBits.cpp
@@ -141,15 +141,12 @@ bool PixelBits::test_collision(
   }
 
   // compute the relative position of the intersection rectangle for each bounding_box
-  const int offset_x1 = intersection.get_x() - bounding_box1.get_x();
-  const int offset_y1 = intersection.get_y() - bounding_box1.get_y();
-
-  const int offset_x2 = intersection.get_x() - bounding_box2.get_x();
-  const int offset_y2 = intersection.get_y() - bounding_box2.get_y();
+  Point offset1 = intersection.get_xy() - bounding_box1.get_xy();
+  Point offset2 = intersection.get_xy() - bounding_box2.get_xy();
 
   if (debug_pixel_collisions) {
-    std::cout << "offset_x1 = " << offset_x1 << ", offset_y1 = " << offset_y1;
-    std::cout << ", offset_x2 = " << offset_x2 << ", offset_y2 = " << offset_y2 << std::endl;
+    std::cout << "offset1.x = " << offset1.x << ", offset1.y = " << offset1.y;
+    std::cout << ", offset2.x = " << offset2.x << ", offset2.y = " << offset2.y << std::endl;
   }
 
   // For each row of the intersection, we will call row 'a' the row coming from the right bounding box
@@ -166,16 +163,16 @@ bool PixelBits::test_collision(
 
   // make sure row a starts after row b
   if (bounding_box1.get_x() > bounding_box2.get_x()) {
-    rows_a = this->bits.begin() + offset_y1;
-    rows_b = other.bits.begin() + offset_y2;
-    nb_unused_masks_row_b = offset_x2 >> 5;
-    nb_unused_bits_row_b = offset_x2 & 31;
+    rows_a = this->bits.begin() + offset1.y;
+    rows_b = other.bits.begin() + offset2.y;
+    nb_unused_masks_row_b = offset2.x >> 5;
+    nb_unused_bits_row_b = offset2.x & 31;
   }
   else {
-    rows_a = other.bits.begin() + offset_y2;
-    rows_b = this->bits.begin() + offset_y1;
-    nb_unused_masks_row_b = offset_x1 >> 5;
-    nb_unused_bits_row_b = offset_x1 & 31;
+    rows_a = other.bits.begin() + offset2.y;
+    rows_b = this->bits.begin() + offset1.y;
+    nb_unused_masks_row_b = offset1.x >> 5;
+    nb_unused_bits_row_b = offset1.x & 31;
   }
   nb_used_bits_row_b = 32 - nb_unused_bits_row_b;
 

--- a/src/lowlevel/QuestFiles.cpp
+++ b/src/lowlevel/QuestFiles.cpp
@@ -25,8 +25,7 @@
 #include <physfs.h>
 #include <iostream>
 #include <fstream>
-#include <sstream>
-#include <cstdlib>  // mkstemp(), tmpnam()
+#include <cstdlib>  // exit(), mkstemp(), tmpnam()
 #include <cstdio>   // remove()
 #ifdef HAVE_UNISTD_H
 #  include <unistd.h>

--- a/src/lowlevel/SpcDecoder.cpp
+++ b/src/lowlevel/SpcDecoder.cpp
@@ -16,6 +16,7 @@
  */
 #include "solarus/lowlevel/SpcDecoder.h"
 #include "solarus/lowlevel/Debug.h"
+#include <string>
 
 namespace Solarus {
 

--- a/src/lowlevel/Surface.cpp
+++ b/src/lowlevel/Surface.cpp
@@ -24,6 +24,7 @@
 #include "solarus/lowlevel/PixelFilter.h"
 #include "solarus/lua/LuaContext.h"
 #include "solarus/Transition.h"
+#include <algorithm>
 #include <sstream>
 
 namespace Solarus {

--- a/src/lowlevel/TextSurface.cpp
+++ b/src/lowlevel/TextSurface.cpp
@@ -27,6 +27,7 @@
 #include "solarus/lua/LuaTools.h"
 #include "solarus/Transition.h"
 #include <lua.hpp>
+#include <memory>
 
 namespace Solarus {
 

--- a/src/lowlevel/Video.cpp
+++ b/src/lowlevel/Video.cpp
@@ -28,9 +28,10 @@
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lowlevel/shaders/ShaderContext.h"
 #include "solarus/Arguments.h"
-#include <algorithm>
-#include <sstream>
 #include <iostream>
+#include <memory>
+#include <sstream>
+#include <utility>
 #include <SDL_render.h>
 
 namespace Solarus {

--- a/src/lowlevel/VideoMode.cpp
+++ b/src/lowlevel/VideoMode.cpp
@@ -18,6 +18,7 @@
 #include "solarus/lowlevel/PixelFilter.h"
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lowlevel/shaders/ShaderContext.h"
+#include <utility>
 
 namespace Solarus {
 

--- a/src/lowlevel/shaders/GLContext.cpp
+++ b/src/lowlevel/shaders/GLContext.cpp
@@ -24,6 +24,7 @@
 #include "solarus/lowlevel/Video.h"
 #include "solarus/lua/LuaContext.h"
 #include "solarus/lua/LuaTools.h"
+#include <string>
 
 
 namespace Solarus {

--- a/src/lua/LuaContext.cpp
+++ b/src/lua/LuaContext.cpp
@@ -300,7 +300,7 @@ void LuaContext::notify_map_suspended(Map& map, bool suspended) {
 void LuaContext::run_item(EquipmentItem& item) {
 
   // Compute the file name, depending on the id of the equipment item.
-  std::string file_name = (std::string) "items/" + item.get_name();
+  std::string file_name = std::string("items/") + item.get_name();
 
   // Load the item's code.
   if (load_file_if_exists(l, file_name)) {

--- a/src/lua/LuaData.cpp
+++ b/src/lua/LuaData.cpp
@@ -18,7 +18,9 @@
 #include "solarus/lowlevel/QuestFiles.h"
 #include "solarus/lua/LuaData.h"
 #include <lua.hpp>
+#include <cstdlib>
 #include <fstream>
+#include <ostream>
 #include <sstream>
 
 namespace Solarus {

--- a/src/movements/PathMovement.cpp
+++ b/src/movements/PathMovement.cpp
@@ -22,6 +22,7 @@
 #include "solarus/lowlevel/Random.h"
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lowlevel/Point.h"
+#include <list>
 
 namespace Solarus {
 


### PR DESCRIPTION
I finished the refactoring of the header inclusion strategy that I started last weekend: let's consider a code unit (a .h/.cpp pair). This code unit includes the standard library headers it needs without relying on transitive includes (*e.g* if the unit uses `std::make_shared`, then it includes `<memory>`, without relying on the fact that another incuded header *may* already include `<memory>`). Then it puts as few includes as possible in the .h file and all the other ones in the .cpp  file to eventually reduce compilation times.

While this strategy leads to more includes, I believe that not relying on transitive includes helps for portability between standard library impementations. Also, it ensures that the code will continue to compile even if we remove a standard library include from one of the headers the code unit included.

I also removed some unused standard library includes and change some `foo_x`/`foo_y` into `Point` instances.