### PR TITLE
Changed to safer modern random engine.

### DIFF
--- a/include/solarus/lowlevel/Random.h
+++ b/include/solarus/lowlevel/Random.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -24,23 +24,16 @@ namespace Solarus {
 /**
  * \brief Provides some functions to compute random numbers.
  */
-class Random {
+namespace Random {
 
-  public:
+void initialize();
+void quit();
 
-    static void initialize();
-    static void quit();
+int get_number(unsigned int x);
+int get_number(int x, int y);
 
-    static int get_number(unsigned int x);
-    static int get_number(unsigned int x, unsigned int y);
-
-  private:
-
-    Random();
-
-};
+}
 
 }
 
 #endif
-

--- a/src/lowlevel/Random.cpp
+++ b/src/lowlevel/Random.cpp
@@ -56,8 +56,16 @@ int get_number(unsigned int x) {
 int get_number(int x, int y) {
 
   // Initialize the engine and the distribution
-  thread_local std::mt19937 engine(std::time(nullptr));
-  thread_local std::uniform_int_distribution<int> dist{};
+  //
+  // The engine is not initialized with std::random_device
+  // because not every main platform support non-deterministic
+  // random numbers generation yet.
+  //
+  // The variables are thread_local so that every thread has
+  // its own to avoid thread-safety problems while still being
+  // more efficient than a mutex-based solution
+  static thread_local std::mt19937 engine(std::time(nullptr));
+  static thread_local std::uniform_int_distribution<int> dist{};
 
   // Type of the parameters of the distribution
   using param_type = std::uniform_int_distribution<int>::param_type;

--- a/src/lowlevel/Random.cpp
+++ b/src/lowlevel/Random.cpp
@@ -64,8 +64,15 @@ int get_number(int x, int y) {
   // The variables are thread_local so that every thread has
   // its own to avoid thread-safety problems while still being
   // more efficient than a mutex-based solution
-  static thread_local std::mt19937 engine(std::time(nullptr));
-  static thread_local std::uniform_int_distribution<int> dist{};
+  //
+  // These variables need to be known in the function but not
+  // needed outside of it, so it is easier to have them as
+  // thread_local function-local variables (one instance per
+  // thread, initialized once, like a static variable) rather
+  // than maintaining them in the body of a class.
+  //
+  thread_local std::mt19937 engine(std::time(nullptr));
+  thread_local std::uniform_int_distribution<int> dist{};
 
   // Type of the parameters of the distribution
   using param_type = std::uniform_int_distribution<int>::param_type;

--- a/src/lowlevel/Random.cpp
+++ b/src/lowlevel/Random.cpp
@@ -16,21 +16,22 @@
  */
 #include "solarus/lowlevel/Random.h"
 #include <ctime>
-#include <cstdlib>
+#include <random>
 
 namespace Solarus {
+namespace Random {
 
 /**
  * \brief Initializes the random number generator.
  */
-void Random::initialize() {
-  std::srand((int) std::time(nullptr));
+void initialize() {
+  // nothing to do
 }
 
 /**
  * \brief Uninitializes the random number generator.
  */
-void Random::quit() {
+void quit() {
   // nothing to do
 }
 
@@ -42,8 +43,8 @@ void Random::quit() {
  * \param x the superior bound
  * \return a random integer number in [0, x[
  */
-int Random::get_number(unsigned int x) {
-  return (int) ((double) x * std::rand() / (RAND_MAX + 1.0));
+int get_number(unsigned int x) {
+  return get_number(0, x);
 }
 
 /**
@@ -52,9 +53,18 @@ int Random::get_number(unsigned int x) {
  * \param y the superior bound
  * \return a random integer number in [x, y[
  */
-int Random::get_number(unsigned int x, unsigned int y) {
-  return x + get_number(y - x);
+int get_number(int x, int y) {
+
+  // Initialize the engine and the distribution
+  thread_local std::mt19937 engine(std::time(nullptr));
+  thread_local std::uniform_int_distribution<int> dist{};
+
+  // Type of the parameters of the distribution
+  using param_type = std::uniform_int_distribution<int>::param_type;
+
+  // Get a random number in [x, y[
+  return dist(engine, param_type{x, y-1});
 }
 
 }
-
+}


### PR DESCRIPTION
I changed the random number generation engine so that it uses the new C++11 `<random>` instead of the old `std::rand`. You can find many articles on the internet about the problems of `std::rand`, like its lack of thread-safety and more than anything else, the lack of guarantees for a standard-compliant function. Even the C11 standard has a note telling that it is not inherently safe. On the other hand, the C++11 `<random>` API is safe and more flexible. The only thing I couldn't do was to use `std::random_device` (which generates non-deterministic random numbers) since some platforms such as MinGW actually always produce the same sequence of numbers.

If needed, we can also create a function to create pseudo-random floating-points number with any distribution we want.