### PR TITLE
Less map::insert, more map::emplace instead.

### DIFF
--- a/src/EntityData.cpp
+++ b/src/EntityData.cpp
@@ -19,7 +19,6 @@
 #include "solarus/lowlevel/Debug.h"
 #include "solarus/lua/LuaTools.h"
 #include <ostream>
-#include <utility>
 
 namespace Solarus {
 
@@ -341,7 +340,7 @@ EntityData::EntityData(EntityType type) :
   // Initialize fields with their default values.
   const EntityTypeDescription& type_description = entity_type_descriptions.at(type);
   for (const EntityFieldDescription& field_description : type_description) {
-    fields.insert(std::make_pair(field_description.key, field_description.default_value));
+    fields.emplace(field_description.key, field_description.default_value);
   }
 }
 

--- a/src/MapData.cpp
+++ b/src/MapData.cpp
@@ -19,7 +19,6 @@
 #include "solarus/lua/LuaTools.h"
 #include "solarus/MapData.h"
 #include <ostream>
-#include <utility>
 
 namespace Solarus {
 
@@ -422,7 +421,7 @@ EntityIndex MapData::add_entity(const EntityData& entity) {
       return EntityIndex();
     }
 
-    named_entities.insert(std::make_pair(entity.get_name(), index));
+    named_entities.emplace(entity.get_name(), index);
   }
 
   entities[layer].push_back(entity);

--- a/src/QuestResources.cpp
+++ b/src/QuestResources.cpp
@@ -77,7 +77,7 @@ namespace {
 QuestResources::QuestResources() {
 
   for (size_t i = 0 ; i < resource_type_names.size(); ++i) {
-    resource_maps.insert(std::make_pair(static_cast<ResourceType>(i), ResourceMap()));
+    resource_maps.emplace(static_cast<ResourceType>(i), ResourceMap());
   }
 }
 
@@ -140,7 +140,7 @@ bool QuestResources::add(
     const std::string& description
 ) {
   ResourceMap& resource = get_elements(resource_type);
-  auto result = resource.insert(std::make_pair(id, description));
+  auto result = resource.emplace(id, description);
   return result.second;
 }
 

--- a/src/SpriteAnimationSet.cpp
+++ b/src/SpriteAnimationSet.cpp
@@ -87,9 +87,10 @@ void SpriteAnimationSet::add_animation(
     directions.emplace_back(direction.get_all_frames(), direction.get_origin());
   }
 
-  animations.insert(std::make_pair(animation_name,
+  animations.emplace(
+    animation_name,
     SpriteAnimation(src_image, directions, frame_delay, frame_to_loop_on)
-  ));
+  );
 }
 
 /**

--- a/src/SpriteData.cpp
+++ b/src/SpriteData.cpp
@@ -180,12 +180,12 @@ std::vector<Rectangle> SpriteAnimationDirectionData::get_all_frames() const {
   for (int row = 0; row < num_rows && frame_number < num_frames; ++row) {
     for (int col = 0; col < num_columns && frame_number < num_frames; ++col) {
 
-      Rectangle frame(
-          xy.x + col * size.width,
-          xy.y + row * size.height,
-          size.width,
-          size.height);
-      frames.push_back(frame);
+      frames.emplace_back(
+        xy.x + col * size.width,
+        xy.y + row * size.height,
+        size.width,
+        size.height
+      );
       ++frame_number;
     }
   }
@@ -474,7 +474,7 @@ SpriteAnimationData& SpriteData::get_animation(
 bool SpriteData::add_animation(
     const std::string& animation_name, const SpriteAnimationData& animation)  {
 
-  const auto& result = animations.insert(std::make_pair(animation_name, animation));
+  const auto& result = animations.emplace(animation_name, animation);
   if (!result.second) {
     // Insertion failed: the name already exists.
     return false;
@@ -644,9 +644,9 @@ int SpriteData::l_animation(lua_State* l) {
       LuaTools::error(l, std::string("Duplicate animation '") + animation_name);
     }
 
-    sprite->animations.insert(std::make_pair(animation_name,
+    sprite->animations.emplace(animation_name,
       SpriteAnimationData(src_image, directions, frame_delay, frame_to_loop_on)
-    ));
+    );
 
     // Set the first animation as the default one.
     if (sprite->animations.size() == 1) {

--- a/src/entities/Tileset.cpp
+++ b/src/entities/Tileset.cpp
@@ -28,7 +28,6 @@
 #include "solarus/lua/LuaTools.h"
 #include <lua.hpp>
 #include <sstream>
-#include <utility>
 #include <vector>
 
 namespace Solarus {
@@ -119,7 +118,7 @@ void Tileset::add_tile_pattern(
     );
   }
 
-  tile_patterns.insert(std::make_pair(id, std::unique_ptr<TilePattern>(tile_pattern)));
+  tile_patterns.emplace(id, std::unique_ptr<TilePattern>(tile_pattern));
 }
 
 /**

--- a/src/entities/TilesetData.cpp
+++ b/src/entities/TilesetData.cpp
@@ -20,7 +20,6 @@
 #include "solarus/lua/LuaTools.h"
 #include <ostream>
 #include <sstream>
-#include <utility>
 
 namespace Solarus {
 
@@ -256,7 +255,7 @@ TilePatternData& TilesetData::get_pattern(const std::string& pattern_id) {
 bool TilesetData::add_pattern(
     const std::string& pattern_id, const TilePatternData& pattern) {
 
-  const auto& result = patterns.insert(std::make_pair(pattern_id, pattern));
+  const auto& result = patterns.emplace(pattern_id, pattern);
   if (!result.second) {
     // Insertion failed: the id already exists.
     return false;

--- a/src/lowlevel/FontResource.cpp
+++ b/src/lowlevel/FontResource.cpp
@@ -107,7 +107,7 @@ void FontResource::load_fonts() {
       font.bitmap_font = nullptr;
     }
 
-    fonts.insert(std::make_pair(font_id, std::move(font)));
+    fonts.emplace(font_id, std::move(font));
   }
 
   fonts_loaded = true;
@@ -214,7 +214,7 @@ TTF_Font& FontResource::get_outline_font(const std::string& font_id, int size) {
       + "': " + TTF_GetError()
   );
   OutlineFontReader reader = { std::move(rw), std::move(outline_font) };
-  outline_fonts.insert(std::make_pair(size, std::move(reader)));
+  outline_fonts.emplace(size, std::move(reader));
   return *outline_fonts.at(size).outline_font;
 }
 

--- a/src/lua/EntityApi.cpp
+++ b/src/lua/EntityApi.cpp
@@ -66,7 +66,7 @@ const std::map<EntityType, std::string>& get_entity_internal_type_names() {
   if (result.empty()) {
     for (const auto& kvp : EntityTypeInfo::get_entity_type_names()) {
       std::string internal_type_name = std::string("sol.") + kvp.second;
-      result.insert(std::make_pair(kvp.first, internal_type_name));
+      result.emplace(kvp.first, internal_type_name);
     }
   }
 


### PR DESCRIPTION
I removed a bunch of `map::insert` in the code and replaced them with `map::emplace` which allows to drop the call to `std::make_pair`. It might even be slightly more efficient, but before all, it allows for terser code.