### PR TITLE
Use the standard functions from cctype.

### DIFF
--- a/src/lua/LuaTools.cpp
+++ b/src/lua/LuaTools.cpp
@@ -18,6 +18,7 @@
 #include "solarus/lowlevel/Color.h"
 #include "solarus/lua/LuaException.h"
 #include "solarus/lua/ScopedLuaRef.h"
+#include <cctype>
 #include <sstream>
 
 namespace Solarus {
@@ -50,15 +51,12 @@ int get_positive_index(lua_State* l, int index) {
  */
 bool is_valid_lua_identifier(const std::string& name) {
 
-  if (name.empty() || (name[0] >= '0' && name[0] <= '9')) {
+  if (name.empty() || std::isdigit(name[0])) {
     return false;
   }
 
   for (char character: name) {
-    if (character != '_' &&
-        !(character >= 'a' && character <= 'z') &&
-        !(character >= 'A' && character <= 'Z') &&
-        !(character >= '0' && character <= '9')) {
+    if (!std::isalnum(character) && character != '_') {
       return false;
     }
   }


### PR DESCRIPTION
Use the standard functions from `<cctype>` instead of manually recomputing them. Some additional details, even though they are rather irrelevant:
* It may be a little bit slower since the functions from `<cctype>` have to be locale-aware, but not enough to be noticed.
* The standard only guarantees that the characters `'0' .. '9'` are contiguous. Actually, if the character set was EBCDIC instead of ASCII, the checks for the alphabetical characters would have failed. It shouldn't matter anyway since almost everything is ASCII-based nowadays.