### PR TITLE
Set the default maximum number of items

### DIFF
--- a/src/EquipmentItem.cpp
+++ b/src/EquipmentItem.cpp
@@ -33,7 +33,7 @@ EquipmentItem::EquipmentItem(Equipment& equipment):
   equipment(equipment),
   name(""),
   savegame_variable(""),
-  max_amount(0),
+  max_amount(1000),
   obtainable(true),
   assignable(false),
   can_disappear(false),


### PR DESCRIPTION
to 1000. Should be large enough for most purposes.
Fix #688