### PR TITLE
More constexpr in Rectangle and Color.

### DIFF
--- a/include/solarus/lowlevel/Color.h
+++ b/include/solarus/lowlevel/Color.h
@@ -35,7 +35,7 @@ class Color {
     constexpr Color();
     constexpr Color(int r, int g, int b, int a = 255);
 
-    uint8_t get_alpha() const;
+    constexpr uint8_t get_alpha() const;
     void set_alpha(uint8_t alpha);
     void get_components(uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a) const;
     void set_components(int r, int g, int b, int a = 255);
@@ -53,8 +53,8 @@ class Color {
 
   private:
 
-    friend bool operator==(const Color& lhs, const Color& rhs);
-    friend bool operator!=(const Color& lhs, const Color& rhs);
+    friend constexpr bool operator==(const Color& lhs, const Color& rhs);
+    friend constexpr bool operator!=(const Color& lhs, const Color& rhs);
 
     uint8_t r;     /**< The red component. */
     uint8_t g;     /**< The green component. */
@@ -62,8 +62,8 @@ class Color {
     uint8_t a;     /**< The alpha (opacity) component. 255 is opaque. */
 };
 
-bool operator==(const Color& lhs, const Color& rhs);
-bool operator!=(const Color& lhs, const Color& rhs);
+constexpr bool operator==(const Color& lhs, const Color& rhs);
+constexpr bool operator!=(const Color& lhs, const Color& rhs);
 
 }
 

--- a/include/solarus/lowlevel/Color.inl
+++ b/include/solarus/lowlevel/Color.inl
@@ -48,7 +48,7 @@ constexpr Color::Color(int r, int g, int b, int a):
  * \brief Returns the alpha component of this color.
  * \return The alpha component. 255 is opaque.
  */
-inline uint8_t Color::get_alpha() const {
+constexpr uint8_t Color::get_alpha() const {
   return a;
 }
 
@@ -97,7 +97,7 @@ inline void Color::set_components(int r, int g, int b, int a) {
  * \param rhs Another color.
  * \return \c true if both colors are equal.
  */
-inline bool operator==(const Color& lhs, const Color& rhs) {
+constexpr bool operator==(const Color& lhs, const Color& rhs) {
 
   return lhs.r == rhs.r &&
       lhs.g == rhs.g &&
@@ -111,7 +111,7 @@ inline bool operator==(const Color& lhs, const Color& rhs) {
  * \param rhs Another color.
  * \return \c true if both colors are equal.
  */
-inline bool operator!=(const Color& lhs, const Color& rhs) {
+constexpr bool operator!=(const Color& lhs, const Color& rhs) {
 
   return lhs.r != rhs.r ||
       lhs.g != rhs.g ||

--- a/include/solarus/lowlevel/Point.h
+++ b/include/solarus/lowlevel/Point.h
@@ -58,8 +58,8 @@ class Point {
 // Free functions
 
 // Comparison operators
-bool operator==(const Point& lhs, const Point& rhs);
-bool operator!=(const Point& lhs, const Point& rhs);
+constexpr bool operator==(const Point& lhs, const Point& rhs);
+constexpr bool operator!=(const Point& lhs, const Point& rhs);
 
 // Unary arithmetic operators
 Point operator+(const Point& point);

--- a/include/solarus/lowlevel/Point.inl
+++ b/include/solarus/lowlevel/Point.inl
@@ -89,7 +89,7 @@ inline Point& Point::operator/=(int divisor) {
  * \param rhs Another point.
  * \return \c true if the points are equal.
  */
-inline bool operator==(const Point& lhs, const Point& rhs) {
+constexpr bool operator==(const Point& lhs, const Point& rhs) {
   return lhs.x == rhs.x && lhs.y == rhs.y;
 }
 
@@ -99,7 +99,7 @@ inline bool operator==(const Point& lhs, const Point& rhs) {
  * \param rhs Another point.
  * \return \c true if the points are not equal.
  */
-inline bool operator!=(const Point& lhs, const Point& rhs) {
+constexpr bool operator!=(const Point& lhs, const Point& rhs) {
   return !(lhs == rhs);
 }
 

--- a/include/solarus/lowlevel/Rectangle.h
+++ b/include/solarus/lowlevel/Rectangle.h
@@ -48,14 +48,14 @@ class Rectangle {
     constexpr Rectangle(int x, int y, int width, int height);
     constexpr Rectangle(const Point& xy, const Size& size);
 
-    int get_x() const;
-    int get_y() const;
-    Point get_xy() const;
-    int get_width() const;
-    int get_height() const;
-    Size get_size() const;
-    bool is_flat() const;
-    Point get_center() const;
+    constexpr int get_x() const;
+    constexpr int get_y() const;
+    constexpr Point get_xy() const;
+    constexpr int get_width() const;
+    constexpr int get_height() const;
+    constexpr Size get_size() const;
+    constexpr bool is_flat() const;
+    constexpr Point get_center() const;
 
     void set_x(int x);
     void set_y(int y);
@@ -76,9 +76,9 @@ class Rectangle {
     void add_xy(int dx, int dy);
     void add_xy(const Point& other);
 
-    bool contains(int x, int y) const;
-    bool contains(const Point& point) const;
-    bool contains(const Rectangle& other) const;
+    constexpr bool contains(int x, int y) const;
+    constexpr bool contains(const Point& point) const;
+    constexpr bool contains(const Rectangle& other) const;
     bool overlaps(const Rectangle& other) const;
 
     Rectangle get_intersection(const Rectangle& other) const;
@@ -92,8 +92,8 @@ class Rectangle {
 
 };
 
-bool operator==(const Rectangle& lhs, const Rectangle& rhs);
-bool operator!=(const Rectangle& lhs, const Rectangle& rhs);
+constexpr bool operator==(const Rectangle& lhs, const Rectangle& rhs);
+constexpr bool operator!=(const Rectangle& lhs, const Rectangle& rhs);
 
 SOLARUS_API std::ostream& operator<<(std::ostream& stream, const Rectangle& rectangle);
 

--- a/include/solarus/lowlevel/Rectangle.inl
+++ b/include/solarus/lowlevel/Rectangle.inl
@@ -73,7 +73,7 @@ constexpr Rectangle::Rectangle(const Point& xy, const Size& size):
  * \brief Returns the x coordinate of the top-left corner of this rectangle.
  * \return the x coordinate of the top-left corner
  */
-inline int Rectangle::get_x() const {
+constexpr int Rectangle::get_x() const {
   return rect.x;
 }
 
@@ -81,7 +81,7 @@ inline int Rectangle::get_x() const {
  * \brief Returns the y coordinate of the top-left corner of this rectangle.
  * \return the y coordinate of the top-left corner
  */
-inline int Rectangle::get_y() const {
+constexpr int Rectangle::get_y() const {
   return rect.y;
 }
 
@@ -89,7 +89,7 @@ inline int Rectangle::get_y() const {
  * \brief Returns the coordinates of the top-left corner of this rectangle.
  * \return the coordinates of the top-left corner
  */
-inline Point Rectangle::get_xy() const {
+constexpr Point Rectangle::get_xy() const {
   return { get_x(), get_y() };
 }
 
@@ -97,7 +97,7 @@ inline Point Rectangle::get_xy() const {
  * \brief Returns the center point of this rectangle.
  * \return The center point.
  */
-inline Point Rectangle::get_center() const {
+constexpr Point Rectangle::get_center() const {
 
   return {
       get_x() + get_width() / 2,
@@ -109,7 +109,7 @@ inline Point Rectangle::get_center() const {
  * \brief Returns the width of this rectangle.
  * \return the width
  */
-inline int Rectangle::get_width()  const {
+constexpr int Rectangle::get_width()  const {
   return rect.w;
 }
 
@@ -117,7 +117,7 @@ inline int Rectangle::get_width()  const {
  * \brief Returns the height of this rectangle.
  * \return the height
  */
-inline int Rectangle::get_height() const {
+constexpr int Rectangle::get_height() const {
   return rect.h;
 }
 
@@ -125,7 +125,7 @@ inline int Rectangle::get_height() const {
  * \brief Returns the size of this rectangle.
  * \return the size
  */
-inline Size Rectangle::get_size() const {
+constexpr Size Rectangle::get_size() const {
   return { get_width(), get_height() };
 }
 
@@ -133,7 +133,7 @@ inline Size Rectangle::get_size() const {
  * \brief Returns whether this rectangle is flat.
  * \return true if the width or the height is 0.
  */
-inline bool Rectangle::is_flat() const {
+constexpr bool Rectangle::is_flat() const {
   return get_width() == 0 || get_height() == 0;
 }
 
@@ -278,7 +278,7 @@ inline void Rectangle::add_xy(const Point& dxy) {
  * \param y y coordinate of the point
  * \return true if the point is in this rectangle
  */
-inline bool Rectangle::contains(int x, int y) const {
+constexpr bool Rectangle::contains(int x, int y) const {
   return x >= get_x() && x < get_x() + get_width()
       && y >= get_y() && y < get_y() + get_height();
 }
@@ -288,7 +288,7 @@ inline bool Rectangle::contains(int x, int y) const {
  * \param point point that may be in this rectangle
  * \return true if \a point is in this rectangle
  */
-inline bool Rectangle::contains(const Point& point) const {
+constexpr bool Rectangle::contains(const Point& point) const {
   return contains(point.x, point.y);
 }
 
@@ -297,7 +297,7 @@ inline bool Rectangle::contains(const Point& point) const {
  * \param other another rectangle
  * \return true if the specified rectangle is inside this rectangle
  */
-inline bool Rectangle::contains(const Rectangle& other) const {
+constexpr bool Rectangle::contains(const Rectangle& other) const {
   return contains(other.get_x(), other.get_y())
       && contains(other.get_x() + other.get_width() - 1, other.get_y() + other.get_height() - 1);
 }
@@ -377,7 +377,7 @@ inline Rectangle Rectangle::get_intersection(const Rectangle& other) const {
  * \param rhs second rectangle
  * \return true if both rectangles have the same coordinates and size
  */
-inline bool operator==(const Rectangle& lhs, const Rectangle& rhs) {
+constexpr bool operator==(const Rectangle& lhs, const Rectangle& rhs) {
   return lhs.get_xy() == rhs.get_xy()
       && lhs.get_size() == rhs.get_size();
 }
@@ -388,7 +388,7 @@ inline bool operator==(const Rectangle& lhs, const Rectangle& rhs) {
  * \param rhs second rectangle
  * \return true if the rectangles are not equal
  */
-inline bool operator!=(const Rectangle& lhs, const Rectangle& rhs) {
+constexpr bool operator!=(const Rectangle& lhs, const Rectangle& rhs) {
   return !(rhs == lhs);
 }
 

--- a/include/solarus/lowlevel/Size.h
+++ b/include/solarus/lowlevel/Size.h
@@ -64,8 +64,8 @@ class Size {
 // Free functions
 
 // Comparison operators
-bool operator==(const Size& lhs, const Size& rhs);
-bool operator!=(const Size& lhs, const Size& rhs);
+constexpr bool operator==(const Size& lhs, const Size& rhs);
+constexpr bool operator!=(const Size& lhs, const Size& rhs);
 
 // Arithmetic operators
 Size operator+(Size lhs, const Size& rhs);

--- a/include/solarus/lowlevel/Size.inl
+++ b/include/solarus/lowlevel/Size.inl
@@ -105,7 +105,7 @@ constexpr bool Size::is_square() const {
  * \param rhs Another size.
  * \return \c true if the sizes are equal.
  */
-inline bool operator==(const Size& lhs, const Size& rhs) {
+constexpr bool operator==(const Size& lhs, const Size& rhs) {
   return lhs.width == rhs.width && lhs.height == rhs.height;
 }
 
@@ -115,7 +115,7 @@ inline bool operator==(const Size& lhs, const Size& rhs) {
  * \param rhs Another size.
  * \return \c true if the sizes are not equal.
  */
-inline bool operator!=(const Size& lhs, const Size& rhs) {
+constexpr bool operator!=(const Size& lhs, const Size& rhs) {
   return !(lhs == rhs);
 }
 


### PR DESCRIPTION
I saw that you made `Rectangle` and `Color`'s constructors `constexpr`. These classes might have well have their simple getters `constexpr` then, it doesn't cost anything. This one patch should be harmless (sorry again for the previous one -__-); the game still compiles and runs fine.