### PR TITLE
Geometry::get_angle now takes double parameters.

### DIFF
--- a/include/solarus/lowlevel/Geometry.h
+++ b/include/solarus/lowlevel/Geometry.h
@@ -71,7 +71,7 @@ int get_distance2(int x1, int y1, int x2, int y2);
 double get_distance(const Point& point1, const Point& point2);
 int get_distance2(const Point& point1, const Point& point2);
 int get_manhattan_distance(const Point& point1, const Point& point2);
-double get_angle(int x1, int y1, int x2, int y2);
+double get_angle(double x1, double y1, double x2, double y2);
 double get_angle(const Point& point1, const Point& point2);
 Point get_xy(double angle, int distance);
 Point get_xy(const Point& point1, double angle, int distance);

--- a/src/lowlevel/Geometry.cpp
+++ b/src/lowlevel/Geometry.cpp
@@ -46,20 +46,20 @@ double degrees_to_radians(double degrees) {
  * \param y2 Y coordinate of the second point.
  * \return The angle in radians, between 0 and TWO_PI.
  */
-double get_angle(int x1, int y1, int x2, int y2) {
+double get_angle(double x1, double y1, double x2, double y2) {
 
-  int dx = x2 - x1;
-  int dy = y2 - y1;
+  double dx = x2 - x1;
+  double dy = y2 - y1;
 
   // atan2 is undefined if (y == 0 and x == 0)
-  if (dx == 0 && dy == 0) {
+  if (dx == 0.0 && dy == 0.0) {
     return PI_OVER_2;
   }
 
   double angle = std::atan2(-dy, dx);
 
   // Normalize.
-  if (angle < 0) {
+  if (angle < 0.0) {
     angle += TWO_PI;
   }
 

--- a/src/movements/StraightMovement.cpp
+++ b/src/movements/StraightMovement.cpp
@@ -112,7 +112,7 @@ void StraightMovement::set_x_speed(double x_speed) {
     }
     set_next_move_date_x(now + x_delay);
   }
-  angle = Geometry::get_angle(0, 0, (int) (x_speed * 100), (int) (y_speed * 100));
+  angle = Geometry::get_angle(0.0, 0.0, x_speed * 100.0, y_speed * 100.0);
   initial_xy = get_xy();
   finished = false;
 
@@ -147,7 +147,7 @@ void StraightMovement::set_y_speed(double y_speed) {
     }
     set_next_move_date_y(now + y_delay);
   }
-  angle = Geometry::get_angle(0, 0, (int) (x_speed * 100), (int) (y_speed * 100));
+  angle = Geometry::get_angle(0.0, 0.0, x_speed * 100.0, y_speed * 100.0);
   initial_xy = get_xy();
   finished = false;
 


### PR DESCRIPTION
`Geometry::get_angle` already performed operations with `double` values but took `int` parameters (as you said, probablu because it was only ever given integers at some point). I changed it to take `double` parameters instead.

The only notable difference is that `StraightMovement` doesn't have to cast its `double` values to `int` to feed them to `Geometry::get_angle` anymore. Therefore, it may avoid both a useless cast-to-int-then-back-to-double and a potential loss of precision.