### PR TITLE
Made constructors explicit to make lint tools happy.

### DIFF
--- a/include/solarus/Camera.h
+++ b/include/solarus/Camera.h
@@ -43,7 +43,7 @@ class Camera {
 
   public:
 
-    Camera(Map& map);
+    explicit Camera(Map& map);
 
     void update();
     const Rectangle& get_position() const;

--- a/include/solarus/DialogBoxSystem.h
+++ b/include/solarus/DialogBoxSystem.h
@@ -43,7 +43,7 @@ class DialogBoxSystem {
 
   public:
 
-    DialogBoxSystem(Game& game);
+    explicit DialogBoxSystem(Game& game);
 
     Game& get_game();
     bool is_enabled() const;

--- a/include/solarus/EquipmentItem.h
+++ b/include/solarus/EquipmentItem.h
@@ -40,7 +40,7 @@ class EquipmentItem: public ExportableToLua {
 
   public:
 
-    EquipmentItem(Equipment& equipment);
+    explicit EquipmentItem(Equipment& equipment);
 
     Equipment& get_equipment();
     Game* get_game();

--- a/include/solarus/entities/Arrow.h
+++ b/include/solarus/entities/Arrow.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -30,7 +30,7 @@ class Arrow: public Entity {
 
   public:
 
-    Arrow(const Hero& hero);
+    explicit Arrow(const Hero& hero);
 
     virtual EntityType get_type() const override;
     virtual bool can_be_obstacle() const override;

--- a/include/solarus/entities/Hero.h
+++ b/include/solarus/entities/Hero.h
@@ -53,7 +53,7 @@ class Hero: public Entity {
     /**
      * \name Creation and destruction.
      */
-    Hero(Equipment& equipment);
+    explicit Hero(Equipment& equipment);
 
     /**
      * \name Features.

--- a/include/solarus/entities/Hookshot.h
+++ b/include/solarus/entities/Hookshot.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -30,7 +30,7 @@ class Hookshot: public Entity {
 
   public:
 
-    Hookshot(const Hero& hero);
+    explicit Hookshot(const Hero& hero);
 
     virtual EntityType get_type() const override;
     virtual bool can_be_obstacle() const override;

--- a/include/solarus/entities/Tileset.h
+++ b/include/solarus/entities/Tileset.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -40,7 +40,7 @@ class Tileset {
 
   public:
 
-    Tileset(const std::string& id);
+    explicit Tileset(const std::string& id);
 
     void load();
     void unload();

--- a/include/solarus/lowlevel/InputEvent.h
+++ b/include/solarus/lowlevel/InputEvent.h
@@ -290,7 +290,7 @@ class InputEvent {
 
   private:
 
-    InputEvent(const SDL_Event& event);
+    explicit InputEvent(const SDL_Event& event);
 
     static const KeyboardKey directional_keys[];  /**< array of the keyboard directional keys */
     static bool joypad_enabled;                   /**< true if joypad support is enabled

--- a/include/solarus/lowlevel/Sound.h
+++ b/include/solarus/lowlevel/Sound.h
@@ -57,7 +57,7 @@ class Sound {
     static ov_callbacks ogg_callbacks;           /**< vorbisfile object used to load the encoded sound from memory */
     static size_t cb_read(void* ptr, size_t size, size_t nmemb, void* datasource);
 
-    Sound(const std::string& sound_id = "");
+    explicit Sound(const std::string& sound_id = "");
     ~Sound();
     void load();
     bool start();

--- a/include/solarus/lowlevel/shaders/GL_2DShader.h
+++ b/include/solarus/lowlevel/shaders/GL_2DShader.h
@@ -42,7 +42,7 @@ class GL_2DShader : public Shader {
 
     static bool initialize();
 
-    GL_2DShader(const std::string& shader_name);
+    explicit GL_2DShader(const std::string& shader_name);
 
   private:
 

--- a/include/solarus/lowlevel/shaders/GL_ARBShader.h
+++ b/include/solarus/lowlevel/shaders/GL_ARBShader.h
@@ -40,7 +40,7 @@ class GL_ARBShader : public Shader {
 
     static bool initialize();
 
-    GL_ARBShader(const std::string& shader_name);
+    explicit GL_ARBShader(const std::string& shader_name);
     ~GL_ARBShader();
 
   private:

--- a/include/solarus/lowlevel/shaders/Shader.h
+++ b/include/solarus/lowlevel/shaders/Shader.h
@@ -33,7 +33,7 @@ class Shader {
 
   public:
 
-    Shader(const std::string& shader_name);
+    explicit Shader(const std::string& shader_name);
     virtual ~Shader();
 
     static void set_shading_language_version(const std::string& version);

--- a/include/solarus/lua/LuaContext.h
+++ b/include/solarus/lua/LuaContext.h
@@ -131,7 +131,7 @@ class LuaContext {
     static const std::string movement_jump_module_name;
     static const std::string movement_pixel_module_name;
 
-    LuaContext(MainLoop& main_loop);
+    explicit LuaContext(MainLoop& main_loop);
     ~LuaContext();
 
     static LuaContext& get_lua_context(lua_State* l);

--- a/include/solarus/movements/CircleMovement.h
+++ b/include/solarus/movements/CircleMovement.h
@@ -35,7 +35,7 @@ class CircleMovement: public Movement {
   public:
 
     // creation and destruction
-    CircleMovement(bool ignore_obstacles);
+    explicit CircleMovement(bool ignore_obstacles);
 
     // state
     virtual void update() override;

--- a/include/solarus/movements/FallingOnFloorMovement.h
+++ b/include/solarus/movements/FallingOnFloorMovement.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -37,7 +37,7 @@ class FallingOnFloorMovement: public PixelMovement {
 
   public:
 
-    FallingOnFloorMovement(FallingHeight height);
+    explicit FallingOnFloorMovement(FallingHeight height);
 
 };
 

--- a/include/solarus/movements/PlayerMovement.h
+++ b/include/solarus/movements/PlayerMovement.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -34,7 +34,7 @@ class PlayerMovement: public StraightMovement {
   public:
 
     // creation and destruction
-    PlayerMovement(int speed);
+    explicit PlayerMovement(int speed);
 
     virtual void update() override;
 


### PR DESCRIPTION
I ran [flint](https://github.com/facebook/flint) on the code and it wasn't happy because some constructors weren't  `explicit` and may cause sneaky implicit conversions. I added `explicit` and the code still compiles fine.