### PR TITLE
Improvements suggested by CppCheck.

### DIFF
--- a/include/solarus/Equipment.h
+++ b/include/solarus/Equipment.h
@@ -45,7 +45,7 @@ class SOLARUS_API Equipment {
   public:
 
     // creation and destruction
-    Equipment(Savegame& savegame);
+    explicit Equipment(Savegame& savegame);
 
     Savegame& get_savegame();
     Game* get_game();

--- a/include/solarus/MainLoop.h
+++ b/include/solarus/MainLoop.h
@@ -37,7 +37,7 @@ class SOLARUS_API MainLoop {
 
   public:
 
-    MainLoop(const Arguments& args);
+    explicit MainLoop(const Arguments& args);
     ~MainLoop();
 
     void run();

--- a/include/solarus/Map.h
+++ b/include/solarus/Map.h
@@ -57,7 +57,7 @@ class SOLARUS_API Map: public ExportableToLua {
   public:
 
     // creation and destruction
-    Map(const std::string& id);
+    explicit Map(const std::string& id);
 
     // map properties
     const std::string& get_id() const;

--- a/include/solarus/SolarusFatal.h
+++ b/include/solarus/SolarusFatal.h
@@ -30,7 +30,7 @@ class SOLARUS_API SolarusFatal : public std::exception {
 
   public:
 
-    SolarusFatal(const std::string& error_message);
+    explicit SolarusFatal(const std::string& error_message);
     virtual const char* what() const noexcept override;
 
   private:

--- a/include/solarus/Sprite.h
+++ b/include/solarus/Sprite.h
@@ -53,7 +53,7 @@ class Sprite: public Drawable {
     static void quit();
 
     // creation and destruction
-    Sprite(const std::string& id);
+    explicit Sprite(const std::string& id);
 
     void set_tileset(Tileset& tileset);
 

--- a/include/solarus/SpriteAnimationSet.h
+++ b/include/solarus/SpriteAnimationSet.h
@@ -43,7 +43,7 @@ class SpriteAnimationSet {
 
   public:
 
-    SpriteAnimationSet(const std::string& id);
+    explicit SpriteAnimationSet(const std::string& id);
 
     void set_tileset(Tileset& tileset);
 

--- a/include/solarus/Timer.h
+++ b/include/solarus/Timer.h
@@ -32,7 +32,7 @@ class Timer: public ExportableToLua {
 
   public:
 
-    Timer(uint32_t duration);
+    explicit Timer(uint32_t duration);
 
     bool is_with_sound() const;
     void set_with_sound(bool with_sound);

--- a/include/solarus/Transition.h
+++ b/include/solarus/Transition.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -101,7 +101,7 @@ class SOLARUS_API Transition {
 
   protected:
 
-    Transition(Direction direction);
+    explicit Transition(Direction direction);
 
     Surface* get_previous_surface() const;
 

--- a/include/solarus/TransitionImmediate.h
+++ b/include/solarus/TransitionImmediate.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -32,7 +32,7 @@ class TransitionImmediate: public Transition {
 
   public:
 
-    TransitionImmediate(Direction direction);
+    explicit TransitionImmediate(Direction direction);
 
     virtual void start() override;
     virtual bool is_started() const override;

--- a/include/solarus/TransitionScrolling.h
+++ b/include/solarus/TransitionScrolling.h
@@ -38,7 +38,7 @@ class TransitionScrolling: public Transition {
 
   public:
 
-    TransitionScrolling(Direction direction);
+    explicit TransitionScrolling(Direction direction);
 
     virtual bool needs_previous_surface() const override;
 

--- a/include/solarus/containers/Quadtree.h
+++ b/include/solarus/containers/Quadtree.h
@@ -45,7 +45,7 @@ class Quadtree {
   public:
 
     Quadtree();
-    Quadtree(const Rectangle& space);
+    explicit Quadtree(const Rectangle& space);
 
     void clear();
     void initialize(const Rectangle& space);
@@ -85,7 +85,7 @@ class Quadtree {
       public:
 
         Node();
-        Node(const Rectangle& cell);
+        explicit Node(const Rectangle& cell);
 
         void clear();
         void initialize(const Rectangle& cell);

--- a/include/solarus/hero/BowState.h
+++ b/include/solarus/hero/BowState.h
@@ -28,7 +28,7 @@ class Hero::BowState: public HeroState {
 
   public:
 
-    BowState(Hero& hero);
+    explicit BowState(Hero& hero);
 
     virtual void start(const HeroState* previous_state) override;
     virtual void update() override;

--- a/include/solarus/hero/FallingState.h
+++ b/include/solarus/hero/FallingState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -28,7 +28,7 @@ class Hero::FallingState: public HeroState {
 
   public:
 
-    FallingState(Hero& hero);
+    explicit FallingState(Hero& hero);
 
     virtual void start(const HeroState* previous_state) override;
     virtual void stop(const HeroState* next_state) override;

--- a/include/solarus/hero/FreeState.h
+++ b/include/solarus/hero/FreeState.h
@@ -30,7 +30,7 @@ class Hero::FreeState: public Hero::PlayerMovementState {
 
   public:
 
-    FreeState(Hero& hero);
+    explicit FreeState(Hero& hero);
 
     virtual void start(const HeroState* previous_state) override;
     virtual void stop(const HeroState* next_state) override;

--- a/include/solarus/hero/FreezedState.h
+++ b/include/solarus/hero/FreezedState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -28,7 +28,7 @@ class Hero::FreezedState: public HeroState {
 
   public:
 
-    FreezedState(Hero& hero);
+    explicit FreezedState(Hero& hero);
 
     virtual void start(const HeroState* previous_state) override;
 

--- a/include/solarus/hero/GrabbingState.h
+++ b/include/solarus/hero/GrabbingState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -28,7 +28,7 @@ class Hero::GrabbingState: public HeroState {
 
   public:
 
-    GrabbingState(Hero& hero);
+    explicit GrabbingState(Hero& hero);
 
     virtual void start(const HeroState* previous_state) override;
     virtual void update() override;

--- a/include/solarus/hero/HookshotState.h
+++ b/include/solarus/hero/HookshotState.h
@@ -31,7 +31,7 @@ class Hero::HookshotState: public HeroState {
 
   public:
 
-    HookshotState(Hero& hero);
+    explicit HookshotState(Hero& hero);
 
     virtual void start(const HeroState* previous_state) override;
     virtual void stop(const HeroState* next_state) override;

--- a/include/solarus/hero/PlungingState.h
+++ b/include/solarus/hero/PlungingState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -28,7 +28,7 @@ class Hero::PlungingState: public HeroState {
 
   public:
 
-    PlungingState(Hero& hero);
+    explicit PlungingState(Hero& hero);
 
     virtual void start(const HeroState* previous_state) override;
     virtual void update() override;

--- a/include/solarus/hero/PullingState.h
+++ b/include/solarus/hero/PullingState.h
@@ -31,7 +31,7 @@ class Hero::PullingState: public HeroState {
 
   public:
 
-    PullingState(Hero& hero);
+    explicit PullingState(Hero& hero);
 
     virtual void start(const HeroState* previous_state) override;
     virtual void stop(const HeroState* next_state) override;

--- a/include/solarus/hero/PushingState.h
+++ b/include/solarus/hero/PushingState.h
@@ -31,7 +31,7 @@ class Hero::PushingState: public HeroState {
 
   public:
 
-    PushingState(Hero& hero);
+    explicit PushingState(Hero& hero);
 
     virtual void start(const HeroState* previous_state) override;
     virtual void stop(const HeroState* next_state) override;

--- a/include/solarus/hero/SpinAttackState.h
+++ b/include/solarus/hero/SpinAttackState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -28,7 +28,7 @@ class Hero::SpinAttackState: public HeroState {
 
   public:
 
-    SpinAttackState(Hero& hero);
+    explicit SpinAttackState(Hero& hero);
 
     virtual void start(const HeroState* previous_state) override;
     virtual void stop(const HeroState* next_state) override;

--- a/include/solarus/hero/SwimmingState.h
+++ b/include/solarus/hero/SwimmingState.h
@@ -29,7 +29,7 @@ class Hero::SwimmingState: public Hero::PlayerMovementState {
 
   public:
 
-    SwimmingState(Hero& hero);
+    explicit SwimmingState(Hero& hero);
 
     virtual void start(const HeroState* previous_state) override;
     virtual void stop(const HeroState* next_state) override;

--- a/include/solarus/hero/SwordLoadingState.h
+++ b/include/solarus/hero/SwordLoadingState.h
@@ -29,7 +29,7 @@ class Hero::SwordLoadingState: public Hero::PlayerMovementState {
 
   public:
 
-    SwordLoadingState(Hero& hero);
+    explicit SwordLoadingState(Hero& hero);
 
     virtual void start(const HeroState* previous_state) override;
     virtual void update() override;

--- a/include/solarus/hero/SwordSwingingState.h
+++ b/include/solarus/hero/SwordSwingingState.h
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -28,7 +28,7 @@ class Hero::SwordSwingingState: public HeroState {
 
   public:
 
-    SwordSwingingState(Hero& hero);
+    explicit SwordSwingingState(Hero& hero);
 
     virtual void start(const HeroState* previous_state) override;
     virtual void stop(const HeroState* next_state) override;

--- a/include/solarus/hero/SwordTappingState.h
+++ b/include/solarus/hero/SwordTappingState.h
@@ -29,7 +29,7 @@ class Hero::SwordTappingState: public HeroState {
 
   public:
 
-    SwordTappingState(Hero& hero);
+    explicit SwordTappingState(Hero& hero);
 
     virtual void start(const HeroState* previous_state) override;
     virtual void stop(const HeroState* next_state) override;

--- a/include/solarus/movements/Movement.h
+++ b/include/solarus/movements/Movement.h
@@ -102,7 +102,7 @@ class SOLARUS_API Movement: public ExportableToLua {
 
   protected:
 
-    Movement(bool ignore_obstacles = false);
+    explicit Movement(bool ignore_obstacles = false);
 
     // suspended
     uint32_t get_when_suspended() const;

--- a/include/solarus/movements/PathFindingMovement.h
+++ b/include/solarus/movements/PathFindingMovement.h
@@ -37,7 +37,7 @@ class SOLARUS_API PathFindingMovement: public PathMovement {
 
   public:
 
-    PathFindingMovement(int speed);
+    explicit PathFindingMovement(int speed);
 
     void set_target(const EntityPtr& target);
     virtual bool is_finished() const override;

--- a/include/solarus/movements/RandomPathMovement.h
+++ b/include/solarus/movements/RandomPathMovement.h
@@ -34,7 +34,7 @@ class SOLARUS_API RandomPathMovement: public PathMovement {
 
   public:
 
-    RandomPathMovement(int speed);
+    explicit RandomPathMovement(int speed);
 
     virtual void update() override;
     virtual bool is_finished() const override;

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -90,8 +90,6 @@ void Camera::update_fixed_on() {
   Debug::check_assertion(fixed_on != nullptr,
       "Illegal call to Camera::update_fixed_on_hero()");
 
-  int x = 0;
-  int y = 0;
   if (separator_next_scrolling_date == 0) {
     // Normal case: not traversing a separator.
 
@@ -99,8 +97,8 @@ void Camera::update_fixed_on() {
     const Point& hero_center = fixed_on->get_center_point();
     const int hero_x = hero_center.x;
     const int hero_y = hero_center.y;
-    x = hero_x - get_width() / 2;
-    y = hero_y - get_height() / 2;
+    int x = hero_x - get_width() / 2;
+    int y = hero_y - get_height() / 2;
 
     // Then apply constraints of both separators and map limits.
     this->position = apply_separators_and_map_bounds(Rectangle(x, y, get_width(), get_height()));

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -254,10 +254,8 @@ const Equipment& Game::get_equipment() const {
  */
 bool Game::notify_input(const InputEvent& event) {
 
-  bool handled = false;
-
   if (current_map != nullptr && current_map->is_loaded()) {
-    handled = get_lua_context().game_on_input(*this, event);
+    bool handled = get_lua_context().game_on_input(*this, event);
     if (!handled) {
       handled = current_map->notify_input(event);
       if (!handled) {

--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -641,12 +641,11 @@ void Sprite::update() {
       || synchronize_to->get_current_direction() > get_nb_directions()
       || synchronize_to->get_current_frame() > get_nb_frames()) {
     // update the frames normally (with the time)
-    int next_frame;
     while (!finished && !is_suspended() && !paused && get_frame_delay() > 0
         && now >= next_frame_date) {
 
       // we get the next frame
-      next_frame = get_next_frame();
+      int next_frame = get_next_frame();
 
       // test whether the animation is finished
       if (next_frame == -1) {


### PR DESCRIPTION
These changes follow suggestions made by CppCheck that flint didn't cover. Mainly:
* Add `explicit` to even more constructors.
* Reduce the scope of some variables.