### PR TITLE
Additional CppCheck suggestions.

### DIFF
--- a/src/TransitionFade.cpp
+++ b/src/TransitionFade.cpp
@@ -34,6 +34,7 @@ TransitionFade::TransitionFade(Direction direction, Surface& dst_surface):
   Transition(direction),
   finished(false),
   alpha(-1),
+  next_frame_date(0),
   dst_surface(&dst_surface),
   colored(true),
   transition_color(Color::black) {

--- a/src/entities/Stairs.cpp
+++ b/src/entities/Stairs.cpp
@@ -282,14 +282,12 @@ std::string Stairs::get_path(Way way) {
   if (way == REVERSE_WAY) {
     std::string inverse_path = "";
     std::string::reverse_iterator it;
-    int direction = 0;
     for (it = path.rbegin(); it != path.rend(); ++it) {
-      direction = *it - '0';
+      int direction = *it - '0';
       direction = (direction + 4) % 8;
       inverse_path += '0' + direction;
     }
     path = inverse_path;
-//    path += '0' + direction;
   }
 
   return path;


### PR DESCRIPTION
Just two quick fixes proposed by CppCheck, after we talked about what to do with them:
* Reduced the scope of `direction`.
* Initialized `next_frame_date` in `TransitionFade`'s constructor.