### PR TITLE
New flint sources. Fixed overly explicit constructors.

### DIFF
--- a/include/solarus/SavegameConverterV1.h
+++ b/include/solarus/SavegameConverterV1.h
@@ -37,7 +37,7 @@ class SavegameConverterV1 {
   public:
 
     // creation and destruction
-    SavegameConverterV1(const std::string& file_name);
+    explicit SavegameConverterV1(const std::string& file_name);
 
     // data
     std::string get_string(int index);

--- a/include/solarus/lowlevel/Sound.h
+++ b/include/solarus/lowlevel/Sound.h
@@ -57,7 +57,8 @@ class Sound {
     static ov_callbacks ogg_callbacks;           /**< vorbisfile object used to load the encoded sound from memory */
     static size_t cb_read(void* ptr, size_t size, size_t nmemb, void* datasource);
 
-    explicit Sound(const std::string& sound_id = "");
+    Sound();
+    explicit Sound(const std::string& sound_id);
     ~Sound();
     void load();
     bool start();

--- a/include/solarus/movements/Movement.h
+++ b/include/solarus/movements/Movement.h
@@ -102,7 +102,8 @@ class SOLARUS_API Movement: public ExportableToLua {
 
   protected:
 
-    explicit Movement(bool ignore_obstacles = false);
+    Movement();
+    explicit Movement(bool ignore_obstacles);
 
     // suspended
     uint32_t get_when_suspended() const;

--- a/include/solarus/movements/RandomMovement.h
+++ b/include/solarus/movements/RandomMovement.h
@@ -33,7 +33,8 @@ class RandomMovement: public StraightMovement {
 
   public:
 
-    RandomMovement(int speed, int max_radius = 0);
+    explicit RandomMovement(int speed);
+    RandomMovement(int speed, int max_radius);
 
     virtual void notify_object_controlled() override;
     virtual void update() override;

--- a/src/lowlevel/Sound.cpp
+++ b/src/lowlevel/Sound.cpp
@@ -42,6 +42,14 @@ ov_callbacks Sound::ogg_callbacks = {
 
 /**
  * \brief Creates a new Ogg Vorbis sound.
+ */
+Sound::Sound():
+  Sound(std::string("")) {
+
+}
+
+/**
+ * \brief Creates a new Ogg Vorbis sound.
  * \param sound_id id of the sound: name of a .ogg file in the sounds subdirectory,
  * without the extension (.ogg is added automatically)
  */

--- a/src/movements/Movement.cpp
+++ b/src/movements/Movement.cpp
@@ -27,6 +27,14 @@ namespace Solarus {
 
 /**
  * \brief Constructor.
+ */
+Movement::Movement():
+  Movement(false) {
+
+}
+
+/**
+ * \brief Constructor.
  * \param ignore_obstacles When there is a map and the movement is attached to
  * an entity of this map, indicates whether the movement should ignore
  * obstacles.

--- a/src/movements/RandomMovement.cpp
+++ b/src/movements/RandomMovement.cpp
@@ -28,6 +28,15 @@ namespace Solarus {
 /**
  * \brief Constructor.
  * \param speed Speed of the movement in pixels per seconds.
+ */
+RandomMovement::RandomMovement(int speed):
+  RandomMovement(speed, 0) {
+
+}
+
+/**
+ * \brief Constructor.
+ * \param speed Speed of the movement in pixels per seconds.
  * \param max_radius if the object goes further than this distance, it will come back
  */
 RandomMovement::RandomMovement(int speed, int max_radius):


### PR DESCRIPTION
I compiled `flint` from its most recent sources instead of using the old binaries and it found some things that neither its old version nor CppCheck were able to find: two additional constructors that would benefit from being marked `explicit`.

However, I noticed that in some cases, marking `explicit` a constructor that had a default parameter would also make `explicit` either the default constructor or the constructor with two parameters. That's overly restrictive and not really what we want so I tweaked the code so that there are two constructors instead, only the one with one parameter is marked `explicit`, and the one with the least parameters forwards the appropriate values to the one with more parameters.