### PR TITLE
New function to execute arbitrary code when debugging.

### DIFF
--- a/include/solarus/lowlevel/Debug.h
+++ b/include/solarus/lowlevel/Debug.h
@@ -45,6 +45,19 @@ void SOLARUS_API check_assertion(bool assertion, const char* error_message);
 void SOLARUS_API check_assertion(bool assertion, const std::string& error_message);
 void SOLARUS_API die(const std::string& error_message);
 
+/**
+ * \brief Execute an arbitrary function in debug mode.
+ */
+template<typename Function>
+void execute(Function&& func)
+{
+#ifndef NDEBUG
+    func();
+#else
+    (void) func;
+#endif
+}
+
 }
 
 }

--- a/include/solarus/lowlevel/Debug.h
+++ b/include/solarus/lowlevel/Debug.h
@@ -49,7 +49,7 @@ void SOLARUS_API die(const std::string& error_message);
  * \brief Execute an arbitrary function in debug mode.
  */
 template<typename Function>
-void execute(Function&& func)
+void execute_if_debug(Function&& func)
 {
 #ifndef NDEBUG
     func();

--- a/src/lua/LuaContext.cpp
+++ b/src/lua/LuaContext.cpp
@@ -1023,7 +1023,7 @@ void LuaContext::push_userdata(lua_State* l, ExportableToLua& userdata) {
     luaL_getmetatable(l, userdata.get_lua_type_name().c_str());
                                   // ... all_udata lightudata udata mt
 
-    Debug::execute([&] {
+    Debug::execute_if_debug([&] {
       Debug::check_assertion(!lua_isnil(l, -1),
           std::string("Userdata of type '" + userdata.get_lua_type_name()
           + "' has no metatable, this is a memory leak"));

--- a/src/lua/LuaContext.cpp
+++ b/src/lua/LuaContext.cpp
@@ -1023,20 +1023,20 @@ void LuaContext::push_userdata(lua_State* l, ExportableToLua& userdata) {
     luaL_getmetatable(l, userdata.get_lua_type_name().c_str());
                                   // ... all_udata lightudata udata mt
 
-#ifndef NDEBUG
-    Debug::check_assertion(!lua_isnil(l, -1),
-        std::string("Userdata of type '" + userdata.get_lua_type_name()
-        + "' has no metatable, this is a memory leak"));
+    Debug::execute([&] {
+      Debug::check_assertion(!lua_isnil(l, -1),
+          std::string("Userdata of type '" + userdata.get_lua_type_name()
+          + "' has no metatable, this is a memory leak"));
 
-    lua_getfield(l, -1, "__gc");
-                                  // ... all_udata lightudata udata mt gc
-    Debug::check_assertion(lua_isfunction(l, -1),
-        std::string("Userdata of type '") + userdata.get_lua_type_name()
-        + "' must have the __gc function LuaContext::userdata_meta_gc");
-                                  // ... all_udata lightudata udata mt gc
-    lua_pop(l, 1);
-                                  // ... all_udata lightudata udata mt
-#endif
+      lua_getfield(l, -1, "__gc");
+                                    // ... all_udata lightudata udata mt gc
+      Debug::check_assertion(lua_isfunction(l, -1),
+          std::string("Userdata of type '") + userdata.get_lua_type_name()
+          + "' must have the __gc function LuaContext::userdata_meta_gc");
+                                    // ... all_udata lightudata udata mt gc
+      lua_pop(l, 1);
+                                    // ... all_udata lightudata udata mt
+    });
 
     lua_setmetatable(l, -2);
                                   // ... all_udata lightudata udata

--- a/src/lua/TimerApi.cpp
+++ b/src/lua/TimerApi.cpp
@@ -124,7 +124,7 @@ void LuaContext::add_timer(
 
   callback_ref.push();
 
-  Debug::execute([&] {
+  Debug::execute_if_debug([&] {
     // Sanity check: check the uniqueness of the ref.
     for (const auto& kvp: timers) {
       if (kvp.second.callback_ref.get() == callback_ref.get()) {

--- a/src/lua/TimerApi.cpp
+++ b/src/lua/TimerApi.cpp
@@ -124,17 +124,17 @@ void LuaContext::add_timer(
 
   callback_ref.push();
 
-#ifndef NDEBUG
-  // Sanity check: check the uniqueness of the ref.
-  for (const auto& kvp: timers) {
-    if (kvp.second.callback_ref.get() == callback_ref.get()) {
-      std::ostringstream oss;
-      oss << "Callback ref " << callback_ref.get()
-          << " is already used by a timer (duplicate luaL_unref?)";
-      Debug::die(oss.str());
+  Debug::execute([&] {
+    // Sanity check: check the uniqueness of the ref.
+    for (const auto& kvp: timers) {
+      if (kvp.second.callback_ref.get() == callback_ref.get()) {
+        std::ostringstream oss;
+        oss << "Callback ref " << callback_ref.get()
+            << " is already used by a timer (duplicate luaL_unref?)";
+        Debug::die(oss.str());
+      }
     }
-  }
-#endif
+  });
 
   Debug::check_assertion(timers.find(timer) == timers.end(),
       "Duplicate timer in the system");


### PR DESCRIPTION
The `NDEBUG` checks begin a bit noisy, I added the function `Debug::execute` to the debugging tools which simply executes a function in debug mode and does nothing otherwise. It allows to wrap in a capturing lambda the code that was in `NDEBUG` guards and feed that lambda to `Debug::execute`, the same way we're already using `LuaTools::exception_boundary_handle`.

I used it directly into two places but didn't modify the third_party libraries that were using it. I hope that it may simplify debug checks without uglifying them too much :)