### PR TITLE
Changes necessary to compile with MSVC.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ tools/solarus-editor.jar
 work/unversioned/
 build/
 gcwbuild/
+build_linux/
+build_vs/
+commit.txt

--- a/cmake/AddCompilationFlags.cmake
+++ b/cmake/AddCompilationFlags.cmake
@@ -30,11 +30,11 @@ set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Werror -Wextra -pedantic ${CMAKE_CXX_FLAGS_DEB
 # Platform-specific flags.
 if(WIN32)
   # Windows: disable the console by default.
-  if(MSVC)
-    set_target_properties(SOLARUS_ENGINE PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS")
-  elseif(CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "-mwindows ${CMAKE_CXX_FLAGS}")
-  endif()
+  #if(MSVC)
+  #  set_target_properties(SOLARUS_ENGINE PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS")
+  #elseif(CMAKE_COMPILER_IS_GNUCXX)
+  #  set(CMAKE_CXX_FLAGS "-mwindows ${CMAKE_CXX_FLAGS}")
+  #endif()
 endif()
 
 if(GCWZERO)

--- a/include/solarus/Common.h
+++ b/include/solarus/Common.h
@@ -23,6 +23,16 @@
 #ifndef SOLARUS_COMMON_H
 #define SOLARUS_COMMON_H
 
+#pragma warning( disable : 4251 4275 4458 4514 4710 4820 4244 4800)
+ // 4251 needs to have dll-interface to be used by clients of class
+ // 4275 non dll-interface class 'Foo::Bar' used as base for dll-interface class 'Foo::Baz'
+ // 4458 declaration of 'foo' hides class member
+ // 4514 unreferenced inline function has been removed
+ // 4710 function not inlined
+ // 4820 padding added after data member
+ // 4244 'argument': conversion from 'foo' to 'bar', possible loss of data
+ // 4800 'int': forcing value to bool 'true' or 'false' (performance warning)
+
 #include "solarus/config.h"
 
 /**

--- a/include/solarus/CurrentQuest.h
+++ b/include/solarus/CurrentQuest.h
@@ -32,30 +32,28 @@ namespace Solarus {
  * \brief Provides access to data of the current quest.
  */
 namespace CurrentQuest {
+SOLARUS_API void initialize();
+SOLARUS_API void quit();
 
-void SOLARUS_API initialize();
-void SOLARUS_API quit();
+SOLARUS_API QuestResources& get_resources();
+SOLARUS_API bool resource_exists(ResourceType resource_type, const std::string& id);
+SOLARUS_API const std::map<std::string, std::string>& get_resources(ResourceType resource_type);
 
-QuestResources& SOLARUS_API get_resources();
-bool SOLARUS_API resource_exists(ResourceType resource_type, const std::string& id);
-const std::map<std::string, std::string>& SOLARUS_API get_resources(ResourceType resource_type);
+SOLARUS_API bool has_language(const std::string& language_code);
+SOLARUS_API void set_language(const std::string& language_code);
+SOLARUS_API std::string& get_language();
+SOLARUS_API std::string get_language_name(const std::string& language_code);
 
-bool SOLARUS_API has_language(const std::string& language_code);
-void SOLARUS_API set_language(const std::string& language_code);
-std::string& SOLARUS_API get_language();
-std::string SOLARUS_API get_language_name(const std::string& language_code);
+SOLARUS_API StringResources& get_strings();
+SOLARUS_API bool string_exists(const std::string& key);
+SOLARUS_API const std::string& get_string(const std::string& key);
 
-StringResources& SOLARUS_API get_strings();
-bool SOLARUS_API string_exists(const std::string& key);
-const std::string& SOLARUS_API get_string(const std::string& key);
-
-std::map<std::string, Dialog>& SOLARUS_API get_dialogs();
-bool SOLARUS_API dialog_exists(const std::string& dialog_id);
-const Dialog& SOLARUS_API get_dialog(const std::string& dialog_id);
+SOLARUS_API std::map<std::string, Dialog>& get_dialogs();
+SOLARUS_API bool dialog_exists(const std::string& dialog_id);
+SOLARUS_API const Dialog& get_dialog(const std::string& dialog_id);
 
 }
 
 }
 
 #endif
-

--- a/include/solarus/Game.h
+++ b/include/solarus/Game.h
@@ -24,6 +24,8 @@
 #include "solarus/GameCommand.h"
 #include "solarus/KeysEffect.h"
 #include "solarus/Transition.h"
+#include "solarus/GameCommands.h"
+#include "solarus/entities/NonAnimatedRegions.h"
 #include <memory>
 #include <string>
 

--- a/include/solarus/Map.h
+++ b/include/solarus/Map.h
@@ -27,8 +27,10 @@
 #include "solarus/Camera.h"
 #include "solarus/MapData.h"
 #include "solarus/Transition.h"
-#include <memory>
-#include <string>
+#include "solarus/entities/MapEntities.h"
+#include "solarus/entities/Tileset.h"
+#include "solarus/entities/NonAnimatedRegions.h"
+#include "solarus/entities/TilePattern.h"
 
 namespace Solarus {
 

--- a/include/solarus/Sprite.h
+++ b/include/solarus/Sprite.h
@@ -20,6 +20,7 @@
 #include "solarus/Common.h"
 #include "solarus/Drawable.h"
 #include "solarus/SpritePtr.h"
+#include "solarus/entities/NonAnimatedRegions.h"
 #include <map>
 #include <string>
 

--- a/include/solarus/entities/Detector.h
+++ b/include/solarus/entities/Detector.h
@@ -34,7 +34,7 @@ class EquipmentItem;
  * to detect the presence of the hero or other moving entities.
  * Examples of detectors include teletransporters, switches and enemies.
  */
-class Detector: public MapEntity {
+class SOLARUS_API Detector: public MapEntity {
 
   public:
 

--- a/include/solarus/lowlevel/Color.h
+++ b/include/solarus/lowlevel/Color.h
@@ -61,7 +61,7 @@ class SOLARUS_API Color {
     uint8_t a;     /**< The alpha (opacity) component. 255 is opaque. */
 };
 
-SOLARUS_API bool operator==(const Color& lhs, const Color& rhs);
+//SOLARUS_API bool operator==(const Color& lhs, const Color& rhs);
 
 }
 

--- a/include/solarus/lowlevel/Debug.h
+++ b/include/solarus/lowlevel/Debug.h
@@ -35,15 +35,15 @@ class CommandLine;
  */
 namespace Debug {
 
-void SOLARUS_API set_die_on_error(bool die);
-void SOLARUS_API set_show_popup_on_die(bool show);
-void SOLARUS_API set_abort_on_die(bool abort);
+SOLARUS_API void set_die_on_error(bool die);
+SOLARUS_API void set_show_popup_on_die(bool show);
+SOLARUS_API void set_abort_on_die(bool abort);
 
-void SOLARUS_API warning(const std::string& message);
-void SOLARUS_API error(const std::string& message);
-void SOLARUS_API check_assertion(bool assertion, const char* error_message);
-void SOLARUS_API check_assertion(bool assertion, const std::string& error_message);
-void SOLARUS_API die(const std::string& error_message);
+SOLARUS_API void warning(const std::string& message);
+SOLARUS_API void error(const std::string& message);
+SOLARUS_API void check_assertion(bool assertion, const char* error_message);
+SOLARUS_API void check_assertion(bool assertion, const std::string& error_message);
+SOLARUS_API void die(const std::string& error_message);
 
 }
 

--- a/include/solarus/lowlevel/Output.h
+++ b/include/solarus/lowlevel/Output.h
@@ -30,8 +30,8 @@ class Arguments;
  */
 namespace Output {
 
-void SOLARUS_API initialize(const Arguments& args);
-void SOLARUS_API quit();
+SOLARUS_API void initialize(const Arguments& args);
+SOLARUS_API void  quit();
 
 }
 

--- a/src/hero/BowState.cpp
+++ b/src/hero/BowState.cpp
@@ -19,6 +19,7 @@
 #include "solarus/hero/HeroSprites.h"
 #include "solarus/entities/MapEntities.h"
 #include "solarus/entities/Arrow.h"
+#include "solarus/entities/NonAnimatedRegions.h"
 #include "solarus/lowlevel/Sound.h"
 #include <memory>
 


### PR DESCRIPTION
AddCompilationFlags.cmake
  this line was giving me trouble:
  set_target_properties(SOLARUS_ENGINE PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS")

Common.h
  ignoring some warnings

CurrentQuest.h, Debug.h, Output.h
  moved SOLARUS_API (__declspec(dllexport)) to the beginning of the
  function declarations where windows likes it.

Detector.h
  added SOLARUS_API to class

Game.h, Map.h, Sprite.h, BowState.cpp
  Added includes. We were failing a static_assert in
  C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\memory

		// TEMPLATE CLASS default_delete
	template<class _Ty>
		struct default_delete
		{	// default deleter for unique_ptr
		_CONST_FUN default_delete() _NOEXCEPT = default;

		template<class _Ty2,
			class = typename enable_if<is_convertible<_Ty2 *, _Ty *>::value,
				void>::type>
			default_delete(const default_delete<_Ty2>&) _NOEXCEPT
			{	// construct from another default_delete
			}

		void operator()(_Ty *_Ptr) const _NOEXCEPT
			{	// delete a pointer
			static_assert(0 < sizeof (_Ty),
				"can't delete an incomplete type");
			delete _Ptr;
			}
		};

Color.h
    commented this out:
	  SOLARUS_API bool operator==(const Color& lhs, const Color& rhs);
	Error	C2375	'Solarus::operator ==': redefinition; different linkage (compiling source file C:\Users\Kyle\Dropbox\solarus_v_1_4_fresh\solarus\src\entities\AnimatedTilePattern.cpp)	solarus	C:\Users\Kyle\Dropbox\solarus_v_1_4_fresh\solarus\include\solarus\lowlevel\Color.h	64

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/christopho/solarus/772)
<!-- Reviewable:end -->
