### PR TITLE
Fix linker error with libsolarus_testing.

### DIFF
--- a/include/solarus/entities/Npc.h
+++ b/include/solarus/entities/Npc.h
@@ -45,7 +45,7 @@ namespace Solarus {
  * interactive entity, and the map script has to handle explicitly its
  * animations (if any).
  */
-class Npc: public Detector {
+class SOLARUS_API Npc: public Detector {
 
   public:
 


### PR DESCRIPTION
This patch fixes a linker error I got while trying to build libsolarus_testing with MinGW.