### PR TITLE
More point semantics for get_ground_from_entity.

### DIFF
--- a/include/solarus/Map.h
+++ b/include/solarus/Map.h
@@ -161,6 +161,7 @@ class SOLARUS_API Map: public ExportableToLua {
     Ground get_ground(int layer, int x, int y) const;
     Ground get_ground(int layer, const Point& xy) const;
     Ground get_ground_from_entity(const Entity& entity, int x, int y) const;
+    Ground get_ground_from_entity(const Entity& entity, const Point& xy) const;
 
     // collisions with detectors (checked after a move)
     void check_collision_with_detectors(Entity& entity);

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -1116,7 +1116,7 @@ Ground Map::get_ground(int layer, int x, int y) const {
  * Static tiles and dynamic entities are all taken into account here.
  *
  * \param layer Layer of the point.
- * \param xy Coordinate of the point.
+ * \param xy Coordinates of the point.
  * \return The ground at this place.
  */
 Ground Map::get_ground(int layer, const Point& xy) const {
@@ -1142,6 +1142,27 @@ Ground Map::get_ground(int layer, const Point& xy) const {
  * \return The ground at this place.
  */
 Ground Map::get_ground_from_entity(const Entity& entity, int x, int y) const {
+  return get_ground_from_entity(entity, Point(x, y));
+}
+
+/**
+ * \brief Returns the modified ground of an entity at the specified point.
+ *
+ * The point is assumed to overlap the entity.
+ *
+ * The point only matters if the ground is diagonal.
+ * When an entity has a diagonal ground, only 8x8 squares on the diagonal of
+ * that entity are diagonal grounds, other ones are resolved Ground::WALL on a
+ * side and Ground::TRAVERSABLE or Ground::DEEP_WATER on the other side.
+ *
+ * A current limitation is that entities with diagonal grounds must be aligned
+ * to the 8x8 grid to work correctly.
+ *
+ * \param entity Entity whose modified ground to get.
+ * \param xy Coordinates of the point.
+ * \return The ground at this place.
+ */
+Ground Map::get_ground_from_entity(const Entity& entity, const Point& xy) const {
 
   const Ground ground = entity.get_modified_ground();
   if (!GroundInfo::is_ground_diagonal(ground)) {
@@ -1164,14 +1185,8 @@ Ground Map::get_ground_from_entity(const Entity& entity, int x, int y) const {
     return ground;
   }
 
-  const Point point_in_entity = {
-      x - entity.get_top_left_x(),
-      y - entity.get_top_left_y()
-  };
-  const Point square_in_entity = {
-      point_in_entity.x / 8,
-      point_in_entity.y / 8
-  };
+  const Point point_in_entity = xy - entity.get_top_left_xy();
+  const Point square_in_entity = point_in_entity / 8;
 
   const int num_squares = entity.get_width() / 8;
   int sum = 0;

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -1076,14 +1076,27 @@ bool Map::has_empty_ground(int layer, const Rectangle& collision_box) const {
  * \return The ground at this place.
  */
 Ground Map::get_ground(int layer, int x, int y) const {
+  return get_ground(layer, Point(x, y));
+}
 
-  if (test_collision_with_border(x, y)) {
+/**
+ * \brief Returns the ground at the specified point.
+ *
+ * Static tiles and dynamic entities are all taken into account here.
+ *
+ * \param layer Layer of the point.
+ * \param xy Coordinates of the point.
+ * \return The ground at this place.
+ */
+Ground Map::get_ground(int layer, const Point& xy) const {
+
+  if (test_collision_with_border(xy)) {
     // Outside the map bounds.
     return Ground::EMPTY;
   }
 
   // See if a dynamic entity changes the ground.
-  const Rectangle box(Point(x, y), Size(1, 1));
+  const Rectangle box(xy, Size(1, 1));
   std::vector<EntityPtr> entities_nearby;
   get_entities().get_entities_in_rectangle_sorted(box, entities_nearby);
 
@@ -1097,30 +1110,17 @@ Ground Map::get_ground(int layer, int x, int y) const {
       continue;
     }
 
-    if (entity_nearby.overlaps(x, y) &&
+    if (entity_nearby.overlaps(xy) &&
         entity_nearby.get_layer() == layer &&
         entity_nearby.is_enabled() &&
         !entity_nearby.is_being_removed()
     ) {
-      return get_ground_from_entity(entity_nearby, x, y);
+      return get_ground_from_entity(entity_nearby, xy);
     }
   }
 
   // Otherwise, return the ground defined by static tiles (this is very fast).
-  return entities->get_tile_ground(layer, x, y);
-}
-
-/**
- * \brief Returns the ground at the specified point.
- *
- * Static tiles and dynamic entities are all taken into account here.
- *
- * \param layer Layer of the point.
- * \param xy Coordinates of the point.
- * \return The ground at this place.
- */
-Ground Map::get_ground(int layer, const Point& xy) const {
-  return get_ground(layer, xy.x, xy.y);
+  return entities->get_tile_ground(layer, xy.x, xy.y);
 }
 
 /**


### PR DESCRIPTION
This is a routine change to reduce the code by using more point semantics in `Map::get_ground_from_entity`. It also introduces an overload that takes a `Point` for symmetry in the API and fixes a small typo.