### PR TITLE
MenuApi.cpp - Fixed invalidated iterator bug in MenuApi.cpp LuaContex…

### DIFF
--- a/cmake/AddCompilationFlags.cmake
+++ b/cmake/AddCompilationFlags.cmake
@@ -4,6 +4,8 @@
 if(MINGW)
   # To avoid a compilation error in vorbisfile.h with fseeko64.
   set(CMAKE_CXX_FLAGS "-std=gnu++11 ${CMAKE_CXX_FLAGS}")
+elseif(MSVC)
+  # c++11 Enabled by default.
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(CMAKE_CXX_COMPILER "/usr/bin/clang++")
   set(CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++ ${CMAKE_CXX_FLAGS}")
@@ -21,20 +23,25 @@ endif()
 
 # Warnings and errors.
 
-# Be less pedantic in release builds for users.
-set(CMAKE_CXX_FLAGS_RELEASE "-Wno-error -Wno-all -Wno-unknown-pragmas -Wno-fatal-errors -Wno-extra ${CMAKE_CXX_FLAGS_RELEASE}")
+if (MSVC)
+  # Only show useful warnings in MSVC.
+  set(CMAKE_CXX_FLAGS_DEBUG "/W4 ${CMAKE_CXX_FLAGS_DEBUG}")
+else()
+  # Be less pedantic in release builds for users.
+  set(CMAKE_CXX_FLAGS_RELEASE "-Wno-error -Wno-all -Wno-unknown-pragmas -Wno-fatal-errors -Wno-extra ${CMAKE_CXX_FLAGS_RELEASE}")
 
-# Be more pedantic in debug mode for developers.
-set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Werror -Wextra -pedantic ${CMAKE_CXX_FLAGS_DEBUG}")
+  # Be more pedantic in debug mode for developers.
+  set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Werror -Wextra -pedantic ${CMAKE_CXX_FLAGS_DEBUG}")
+endif()
 
 # Platform-specific flags.
 if(WIN32)
-  # Windows: disable the console by default.
-  #if(MSVC)
-  #  set_target_properties(SOLARUS_ENGINE PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS")
-  #elseif(CMAKE_COMPILER_IS_GNUCXX)
-  #  set(CMAKE_CXX_FLAGS "-mwindows ${CMAKE_CXX_FLAGS}")
-  #endif()
+  #windows: disable the console by default.
+  if(MSVC)
+   #set_target_properties(solarus_engine properties link_flags_release "/subsystem:windows")
+  elseif(cmake_compiler_is_gnucxx)
+   set(cmake_cxx_flags "-mwindows ${cmake_cxx_flags}")
+  endif()
 endif()
 
 if(GCWZERO)

--- a/include/solarus/Common.h
+++ b/include/solarus/Common.h
@@ -23,15 +23,23 @@
 #ifndef SOLARUS_COMMON_H
 #define SOLARUS_COMMON_H
 
-#pragma warning( disable : 4251 4275 4458 4514 4710 4820 4244 4800)
- // 4251 needs to have dll-interface to be used by clients of class
- // 4275 non dll-interface class 'Foo::Bar' used as base for dll-interface class 'Foo::Baz'
- // 4458 declaration of 'foo' hides class member
- // 4514 unreferenced inline function has been removed
- // 4710 function not inlined
- // 4820 padding added after data member
- // 4244 'argument': conversion from 'foo' to 'bar', possible loss of data
- // 4800 'int': forcing value to bool 'true' or 'false' (performance warning)
+#pragma warning( disable : 4251 4275 4458 4514 4710 4820 4244 4800)// 4625 5026 4626 4668 5027 4514 4365)
+// 4251 needs to have dll-interface to be used by clients of class
+// 4275 non dll-interface class 'Foo::Bar' used as base for dll-interface class 'Foo::Baz'
+// 4458 declaration of 'foo' hides class member
+// 4514 unreferenced inline function has been removed
+// 4710 function not inlined
+// 4820 padding added after data member
+// 4244 'argument': conversion from 'foo' to 'bar', possible loss of data
+// 4800 'int': forcing value to bool 'true' or 'false' (performance warning)
+
+// 4625 copy constructor was implicitly defined as deleted because a base class copy constructor is inaccessible or deleted
+// 5026 move constructor was implicitly defined as deleted because a base class move constructor is inaccessible or deleted
+// 4626 assignment operator was implicitly defined as deleted because a base class assignment operator is inaccessible or deleted
+// 4668 '__GNUC__' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
+// 5027 move assignment operator was implicitly defined as deleted because a base class move assignment operator is inaccessible or deleted
+// 4514 unreferenced inline function has been removed
+// 4365 conversion from 'unsigned int' to 'int'
 
 #include "solarus/config.h"
 

--- a/src/GameCommands.cpp
+++ b/src/GameCommands.cpp
@@ -402,39 +402,39 @@ void GameCommands::joypad_hat_moved(int hat, int value) {
       direction_2 = 0;
     }
 
-    std::ostringstream oss;
-    oss << "hat " << hat << ' ' << direction_names[direction_1];
-    const std::string& joypad_string_1 = oss.str();
+    std::ostringstream oss_1;
+    oss_1 << "hat " << hat << ' ' << direction_names[direction_1];
+    const std::string& joypad_string_1 = oss_1.str();
     GameCommand command_1 = get_command_from_joypad(joypad_string_1);
 
-    oss.str("");
-    oss << "hat " << hat << ' ' << direction_names[(direction_1 + 2) % 4];
-    const std::string& inverse_joypad_string_1 = oss.str();
+    oss_1.str("");
+    oss_1 << "hat " << hat << ' ' << direction_names[(direction_1 + 2) % 4];
+    const std::string& inverse_joypad_string_1 = oss_1.str();
     GameCommand inverse_command_1 = get_command_from_joypad(inverse_joypad_string_1);
 
     GameCommand command_2 = GameCommand::NONE;
     GameCommand inverse_command_2 = GameCommand::NONE;
 
     if (direction_2 != -1) {
-      oss.str("");
-      oss << "hat " << hat << ' ' << direction_names[direction_2];
-      const std::string& joypad_string_2 = oss.str();
+      oss_1.str("");
+      oss_1 << "hat " << hat << ' ' << direction_names[direction_2];
+      const std::string& joypad_string_2 = oss_1.str();
       command_2 = get_command_from_joypad(joypad_string_2);
 
-      oss.str("");
-      oss << "hat " << hat << ' ' << direction_names[(direction_2 + 2) % 4];
-      const std::string& inverse_joypad_string_2 = oss.str();
+      oss_1.str("");
+      oss_1 << "hat " << hat << ' ' << direction_names[(direction_2 + 2) % 4];
+      const std::string& inverse_joypad_string_2 = oss_1.str();
       inverse_command_2 = get_command_from_joypad(inverse_joypad_string_2);
     }
     else {
-      std::ostringstream oss;
-      oss << "hat " << hat << ' ' << direction_names[(direction_1 + 1) % 4];
-      const std::string& joypad_string_2 = oss.str();
+      std::ostringstream oss_2;
+      oss_2 << "hat " << hat << ' ' << direction_names[(direction_1 + 1) % 4];
+      const std::string& joypad_string_2 = oss_2.str();
       command_2 = get_command_from_joypad(joypad_string_2);
 
-      oss.str("");
-      oss << "hat " << hat << ' ' << direction_names[(direction_1 + 3) % 4];
-      const std::string& inverse_joypad_string_2 = oss.str();
+      oss_2.str("");
+      oss_2 << "hat " << hat << ' ' << direction_names[(direction_1 + 3) % 4];
+      const std::string& inverse_joypad_string_2 = oss_2.str();
       inverse_command_2 = get_command_from_joypad(inverse_joypad_string_2);
     }
 

--- a/src/MapData.cpp
+++ b/src/MapData.cpp
@@ -610,8 +610,8 @@ bool MapData::insert_entity(const EntityData& entity, const EntityIndex& index) 
     const EntityData& current_entity = *it;
     const std::string& name = current_entity.get_name();
     if (!name.empty()) {
-      EntityIndex& index = named_entities[name];
-      ++index.order;
+      EntityIndex& entity_index = named_entities[name];
+      ++entity_index.order;
     }
   }
 
@@ -654,8 +654,8 @@ bool MapData::remove_entity(const EntityIndex& index) {
     const EntityData& current_entity = *it;
     const std::string& name = current_entity.get_name();
     if (!name.empty()) {
-      EntityIndex& index = named_entities[name];
-      --index.order;
+      EntityIndex& entity_index = named_entities[name];
+      --entity_index.order;
     }
   }
   return true;

--- a/src/entities/Enemy.cpp
+++ b/src/entities/Enemy.cpp
@@ -819,8 +819,8 @@ void Enemy::update() {
   }
 
   if (exploding) {
-    uint32_t now = System::now();
-    if (now >= next_explosion_date) {
+    uint32_t now_explosion = System::now();
+    if (now_explosion >= next_explosion_date) {
 
       // create an explosion
       Point xy;
@@ -831,7 +831,7 @@ void Enemy::update() {
       ));
       Sound::play("explosion");
 
-      next_explosion_date = now + 200;
+      next_explosion_date = now_explosion + 200;
       nb_explosions++;
 
       if (nb_explosions >= 15) {

--- a/src/entities/NonAnimatedRegions.cpp
+++ b/src/entities/NonAnimatedRegions.cpp
@@ -83,11 +83,11 @@ void NonAnimatedRegions::build(std::vector<TilePtr>& rejected_tiles) {
       int tile_width8 = tile.get_width() / 8;
       int tile_height8 = tile.get_height() / 8;
 
-      for (int i = 0; i < tile_height8; i++) {
-        for (int j = 0; j < tile_width8; j++) {
+      for (int j = 0; j < tile_height8; j++) {
+        for (int k = 0; k < tile_width8; k++) {
 
-          int x8 = tile_x8 + j;
-          int y8 = tile_y8 + i;
+          int x8 = tile_x8 + k;
+          int y8 = tile_y8 + j;
           if (x8 >= 0 && x8 < map_width8 && y8 >= 0 && y8 < map_height8) {
             int index = y8 * map_width8 + x8;
             are_squares_animated[index] = true;

--- a/src/lowlevel/Sound.cpp
+++ b/src/lowlevel/Sound.cpp
@@ -355,12 +355,12 @@ ALuint Sound::decode_file(const std::string& file_name) {
   mem.data = QuestFiles::data_file_read(file_name);
 
   OggVorbis_File file;
-  int error = ov_open_callbacks(&mem, &file, nullptr, 0, ogg_callbacks);
+  int open_callbacks_error = ov_open_callbacks(&mem, &file, nullptr, 0, ogg_callbacks);
 
-  if (error) {
+  if (open_callbacks_error) {
     std::ostringstream oss;
     oss << "Cannot load sound file '" << file_name
-        << "' from memory: error " << error;
+        << "' from memory: error " << open_callbacks_error;
     Debug::error(oss.str());
   }
   else {
@@ -426,12 +426,12 @@ ALuint Sound::decode_file(const std::string& file_name) {
           reinterpret_cast<ALshort*>(samples.data()),
           ALsizei(total_bytes_read),
           sample_rate);
-      ALenum error = alGetError();
-      if (error != AL_NO_ERROR) {
+      ALenum al_error = alGetError();
+      if (al_error != AL_NO_ERROR) {
         std::ostringstream oss;
         oss << "Cannot copy the sound samples of '"
             << file_name << "' into buffer " << buffer
-            << ": error " << error;
+            << ": error " << al_error;
         Debug::error(oss.str());
         buffer = AL_NONE;
       }

--- a/src/lowlevel/Video.cpp
+++ b/src/lowlevel/Video.cpp
@@ -587,8 +587,8 @@ std::vector<const VideoMode*> Video::get_video_modes() {
 
   // Return a copy of all_video_modes with const elements.
   std::vector<const VideoMode*> result;
-  for (const VideoMode& video_mode: all_video_modes) {
-    result.push_back(&video_mode);
+  for (const VideoMode& vm: all_video_modes) {
+    result.push_back(&vm);
   }
   return result;
 }
@@ -602,9 +602,9 @@ std::vector<const VideoMode*> Video::get_video_modes() {
 const VideoMode* Video::get_video_mode_by_name(
     const std::string& mode_name) {
 
-  for (const VideoMode& video_mode: all_video_modes) {
-    if (video_mode.get_name() == mode_name) {
-      return &video_mode;
+  for (const VideoMode& vm: all_video_modes) {
+    if (vm.get_name() == mode_name) {
+      return &vm;
     }
   }
 

--- a/src/lua/GameApi.cpp
+++ b/src/lua/GameApi.cpp
@@ -249,10 +249,10 @@ int LuaContext::game_api_start(lua_State* l) {
       LuaTools::error(l, "Cannot start game: there is no map in this quest");
     }
 
-    Game* game = savegame->get_game();
-    if (game != nullptr) {
+    Game* saved_game = savegame->get_game();
+    if (saved_game != nullptr) {
       // A game is already running with this savegame: restart it.
-      game->restart();
+      saved_game->restart();
     }
     else {
       // Create a new game to run.
@@ -261,8 +261,8 @@ int LuaContext::game_api_start(lua_State* l) {
         // Stop any previous game.
         main_loop.get_game()->stop();
       }
-      Game* game = new Game(main_loop, savegame);
-      main_loop.set_game(game);
+      Game* new_game = new Game(main_loop, savegame);
+      main_loop.set_game(new_game);
     }
 
     return 0;

--- a/src/lua/MenuApi.cpp
+++ b/src/lua/MenuApi.cpp
@@ -156,16 +156,16 @@ void LuaContext::destroy_menus() {
  * by this function.
  */
 void LuaContext::update_menus() {
-
   // Destroy the ones that should be removed.
-  for (auto it = menus.begin(); it != menus.end(); ++it) {
-
+  for (auto it = menus.begin(); it != menus.end();) {
     it->recently_added = false;
     if (it->ref.is_empty()) {
       // Empty ref on a menu means that we should remove it.
       // In this case, context must also be nullptr.
       Debug::check_assertion(it->context == nullptr, "Menu with context and no ref");
-      menus.erase(it--);
+      it = menus.erase(it);
+    } else {
+      ++it;
     }
   }
 }

--- a/src/movements/PathFinding.cpp
+++ b/src/movements/PathFinding.cpp
@@ -95,35 +95,35 @@ std::string PathFinding::compute_path() {
   std::string path = "";
 
   Node starting_node;
-  const int index = get_square_index(source);
+  const int index_1 = get_square_index(source);
   starting_node.location = source;
-  starting_node.index = index;
+  starting_node.index = index_1;
   starting_node.previous_cost = 0;
   starting_node.heuristic = total_mdistance;
   starting_node.total_cost = total_mdistance;
   starting_node.direction = ' ';
   starting_node.parent_index = -1;
 
-  open_list[index] = starting_node;
-  open_list_indices.push_front(index);
+  open_list[index_1] = starting_node;
+  open_list_indices.push_front(index_1);
 
   bool finished = false;
   while (!finished) {
 
     // pick the node with the lowest total cost in the open list
-    const int index = open_list_indices.front();
-    Node* current_node = &open_list[index];
+    const int index_2 = open_list_indices.front();
+    Node* current_node = &open_list[index_2];
     open_list_indices.pop_front();
-    closed_list[index] = *current_node;
-    open_list.erase(index);
-    current_node = &closed_list[index];
+    closed_list[index_2] = *current_node;
+    open_list.erase(index_2);
+    current_node = &closed_list[index_2];
 
     //std::cout << System::now() << " picking the lowest cost node in the open list ("
     //  << (open_list_indices.size() + 1) << " elements): "
     //  << current_node->location << ", index = " << current_node->index
     //  << ", cost = " << current_node->previous_cost << " + " << current_node->heuristic << "\n";
 
-    if (index == target_index) {
+    if (index_2 == target_index) {
       //std::cout << "target node was added to the closed list\n";
       finished = true;
       path = rebuild_path(current_node);
@@ -154,7 +154,7 @@ std::string PathFinding::compute_path() {
             // not in the open list: add it
             new_node.heuristic = Geometry::get_manhattan_distance(new_node.location, target);
             new_node.total_cost = new_node.previous_cost + new_node.heuristic;
-            new_node.parent_index = index;
+            new_node.parent_index = index_2;
             new_node.direction = '0' + i;
             open_list[new_node.index] = new_node;
             add_index_sorted(&open_list[new_node.index]);
@@ -169,7 +169,7 @@ std::string PathFinding::compute_path() {
             if (new_node.previous_cost < existing_node->previous_cost) {
               existing_node->previous_cost = new_node.previous_cost;
               existing_node->total_cost = existing_node->previous_cost + existing_node->heuristic;
-              existing_node->parent_index = index;
+              existing_node->parent_index = index_2;
               open_list_indices.sort();
             }
           }

--- a/src/movements/PathMovement.cpp
+++ b/src/movements/PathMovement.cpp
@@ -371,19 +371,19 @@ void PathMovement::snap() {
   snapped_x -= snapped_x % 8;
   snapped_y -= snapped_y % 8;
 
-  uint32_t now = System::now();
+  uint32_t now_1 = System::now();
 
   if (!snapping) {
     // if we haven't started to move the entity towards an intersection of the grid, do it now
     set_snapping_trajectory(Point(x, y), Point(snapped_x, snapped_y));
     snapping = true;
-    stop_snapping_date = now + 500; // timeout
+    stop_snapping_date = now_1 + 500; // timeout
   }
   else {
     // the entity is currently trying to move towards the closest grid intersection
 
-    uint32_t now = System::now();
-    if (now >= stop_snapping_date) {
+    uint32_t now_2 = System::now();
+    if (now_2 >= stop_snapping_date) {
       // we could not snap the entity after the timeout:
       // this is possible when there is an (unlikely) collision with an obstacle that is not aligned to the grid
       // (typically a statue that is being moved);
@@ -391,7 +391,7 @@ void PathMovement::snap() {
       snapped_x += (snapped_x < x) ? 8 : -8;
       snapped_y += (snapped_y < y) ? 8 : -8;
       set_snapping_trajectory(Point(x, y), Point(snapped_x, snapped_y));
-      stop_snapping_date = now + 500;
+      stop_snapping_date = now_2 + 500;
     }
   }
 }

--- a/src/third_party/snes_spc/SPC_Filter.cpp
+++ b/src/third_party/snes_spc/SPC_Filter.cpp
@@ -30,8 +30,8 @@ void SPC_Filter::run( short* io, int count )
 {
 	require( (count & 1) == 0 ); // must be even
 	
-	int const gain = this->gain;
-	int const bass = this->bass;
+	int const g = this->gain;
+	int const b = this->bass;
 	chan_t* c = &ch [2];
 	do
 	{
@@ -50,7 +50,7 @@ void SPC_Filter::run( short* io, int count )
 			int delta = f - pp1;
 			pp1 = f;
 			int s = sum >> (gain_bits + 2);
-			sum += (delta * gain) - (sum >> bass);
+			sum += (delta * g) - (sum >> b);
 			
 			// Clamp to 16 bits
 			if ( (short) s != s )


### PR DESCRIPTION
…t::update_menus() that Visual Studio caught with _ITERATOR_DEBUG_LEVEL = 2 (on by default in Debug mode)

  i.e., menus.erase(it--) when it == menus.begin()
  See http://stackoverflow.com/questions/16269696/erasing-while-iterating-an-stdlist.

Cleaning up warnings that get past /W4 in MSVC.

NonAnimatedRegions.cpp, Enemy.cpp, Sound.cpp, Video.cpp, PathFinding.cpp, GameApi.cpp, PathMovement.cpp, GameCommands.cpp, MapData.cpp, SPC_Filter
  Fixed warnings like this: warning C4456: declaration of 'foo' hides previous local declaration
                  and this: warning C4459: declaration of 'bar' hides global declaration
                  and this: warning C4457: declaration of 'baz' hides function parameter