### PR TITLE
Fix compilation with MSVC 2015 RTM.

### DIFF
--- a/include/solarus/lowlevel/Debug.h
+++ b/include/solarus/lowlevel/Debug.h
@@ -43,7 +43,7 @@ SOLARUS_API void warning(const std::string& message);
 SOLARUS_API void error(const std::string& message);
 SOLARUS_API void check_assertion(bool assertion, const char* error_message);
 SOLARUS_API void check_assertion(bool assertion, const std::string& error_message);
-SOLARUS_API [[noreturn]] void die(const std::string& error_message);
+[[noreturn]] SOLARUS_API void die(const std::string& error_message);
 
 /**
  * \brief Execute an arbitrary function in debug mode.

--- a/include/solarus/lowlevel/Rectangle.h
+++ b/include/solarus/lowlevel/Rectangle.h
@@ -49,23 +49,23 @@ class Rectangle {
     constexpr Rectangle(const Point& xy, const Size& size);
     constexpr Rectangle(const Point& top_left, const Point& bottom_right);
 
-    constexpr int get_x() const;
-    constexpr int get_y() const;
-    constexpr Point get_xy() const;
-    constexpr int get_width() const;
-    constexpr int get_height() const;
-    constexpr Size get_size() const;
-    constexpr bool is_flat() const;
+    int get_x() const;
+    int get_y() const;
+    Point get_xy() const;
+    int get_width() const;
+    int get_height() const;
+    Size get_size() const;
+    bool is_flat() const;
 
-    constexpr int get_bottom() const;
-    constexpr Point get_bottom_left() const;
-    constexpr Point get_bottom_right() const;
-    constexpr Point get_center() const;
-    constexpr int get_left() const;
-    constexpr int get_right() const;
-    constexpr int get_top() const;
-    constexpr Point get_top_left() const;
-    constexpr Point get_top_right() const;
+    int get_bottom() const;
+    Point get_bottom_left() const;
+    Point get_bottom_right() const;
+    Point get_center() const;
+    int get_left() const;
+    int get_right() const;
+    int get_top() const;
+    Point get_top_left() const;
+    Point get_top_right() const;
 
     void set_x(int x);
     void set_y(int y);
@@ -86,9 +86,9 @@ class Rectangle {
     void add_xy(int dx, int dy);
     void add_xy(const Point& other);
 
-    constexpr bool contains(int x, int y) const;
-    constexpr bool contains(const Point& point) const;
-    constexpr bool contains(const Rectangle& other) const;
+    bool contains(int x, int y) const;
+    bool contains(const Point& point) const;
+    bool contains(const Rectangle& other) const;
     bool overlaps(const Rectangle& other) const;
 
     Rectangle get_intersection(const Rectangle& other) const;
@@ -107,8 +107,8 @@ class Rectangle {
 
 };
 
-constexpr bool operator==(const Rectangle& lhs, const Rectangle& rhs);
-constexpr bool operator!=(const Rectangle& lhs, const Rectangle& rhs);
+bool operator==(const Rectangle& lhs, const Rectangle& rhs);
+bool operator!=(const Rectangle& lhs, const Rectangle& rhs);
 
 SOLARUS_API std::ostream& operator<<(std::ostream& stream, const Rectangle& rectangle);
 

--- a/include/solarus/lowlevel/Rectangle.inl
+++ b/include/solarus/lowlevel/Rectangle.inl
@@ -21,7 +21,7 @@ namespace Solarus {
  * \brief Creates a rectangle, without specifying its properties.
  */
 constexpr Rectangle::Rectangle():
-    Rectangle(0, 0, 0, 0)
+    rect({0, 0, 0, 0})
 {}
 
 /**
@@ -30,7 +30,7 @@ constexpr Rectangle::Rectangle():
  * \param y y coordinate of the top-left corner
  */
 constexpr Rectangle::Rectangle(int x, int y):
-    Rectangle(x, y, 0, 0)
+    rect({x, y, 0, 0})
 {}
 
 /**
@@ -46,7 +46,7 @@ constexpr Rectangle::Rectangle(const Point& xy):
  * \param size the rectangle's size
  */
 constexpr Rectangle::Rectangle(const Size& size):
-    Rectangle(0, 0, size.width, size.height)
+    rect({0, 0, size.width, size.height})
 {}
 
 /**
@@ -88,7 +88,7 @@ constexpr Rectangle::Rectangle(const Point& top_left, const Point& bottom_right)
  * \brief Returns the x coordinate of the top-left corner of this rectangle.
  * \return the x coordinate of the top-left corner
  */
-constexpr int Rectangle::get_x() const {
+inline int Rectangle::get_x() const {
   return rect.x;
 }
 
@@ -96,7 +96,7 @@ constexpr int Rectangle::get_x() const {
  * \brief Returns the y coordinate of the top-left corner of this rectangle.
  * \return the y coordinate of the top-left corner
  */
-constexpr int Rectangle::get_y() const {
+inline int Rectangle::get_y() const {
   return rect.y;
 }
 
@@ -104,7 +104,7 @@ constexpr int Rectangle::get_y() const {
  * \brief Returns the coordinates of the top-left corner of this rectangle.
  * \return the coordinates of the top-left corner
  */
-constexpr Point Rectangle::get_xy() const {
+inline Point Rectangle::get_xy() const {
   return { get_x(), get_y() };
 }
 
@@ -115,7 +115,7 @@ constexpr Point Rectangle::get_xy() const {
  *
  * \return The bottom coordinate.
  */
-constexpr int Rectangle::get_bottom() const {
+inline int Rectangle::get_bottom() const {
   return get_top() + get_height();
 }
 
@@ -126,7 +126,7 @@ constexpr int Rectangle::get_bottom() const {
  *
  * \return The bottom-left point.
  */
-constexpr Point Rectangle::get_bottom_left() const {
+inline Point Rectangle::get_bottom_left() const {
   return { get_left(), get_bottom() };
 }
 
@@ -137,15 +137,15 @@ constexpr Point Rectangle::get_bottom_left() const {
  *
  * \return The bottom-right point.
  */
-constexpr Point Rectangle::get_bottom_right() const {
-  return { get_right(), get_bottom() }; 
+inline Point Rectangle::get_bottom_right() const {
+  return { get_right(), get_bottom() };
 }
 
 /**
  * \brief Returns the center point of this rectangle.
  * \return The center point.
  */
-constexpr Point Rectangle::get_center() const {
+inline Point Rectangle::get_center() const {
   return {
       get_left() + get_width() / 2,
       get_top() + get_height() / 2,
@@ -156,7 +156,7 @@ constexpr Point Rectangle::get_center() const {
  * \brief Returns the left coordinate of this rectangle.
  * \return The left coordinate.
  */
-constexpr int Rectangle::get_left() const {
+inline int Rectangle::get_left() const {
   return rect.x;
 }
 
@@ -167,7 +167,7 @@ constexpr int Rectangle::get_left() const {
  *
  * \return The right coordinate.
  */
-constexpr int Rectangle::get_right() const {
+inline int Rectangle::get_right() const {
   return get_left() + get_width();
 }
 
@@ -175,7 +175,7 @@ constexpr int Rectangle::get_right() const {
  * \brief Returns the top coordinate of this rectangle.
  * \return The top coordinate.
  */
-constexpr int Rectangle::get_top() const {
+inline int Rectangle::get_top() const {
   return rect.y;
 }
 
@@ -186,7 +186,7 @@ constexpr int Rectangle::get_top() const {
  *
  * \return The top-left point.
  */
-constexpr Point Rectangle::get_top_left() const {
+inline Point Rectangle::get_top_left() const {
   return { get_left(), get_top() };
 }
 
@@ -197,7 +197,7 @@ constexpr Point Rectangle::get_top_left() const {
  *
  * \return The top-right point.
  */
-constexpr Point Rectangle::get_top_right() const {
+inline Point Rectangle::get_top_right() const {
   return { get_right(), get_top() };
 }
 
@@ -205,7 +205,7 @@ constexpr Point Rectangle::get_top_right() const {
  * \brief Returns the width of this rectangle.
  * \return the width
  */
-constexpr int Rectangle::get_width()  const {
+inline int Rectangle::get_width()  const {
   return rect.w;
 }
 
@@ -213,7 +213,7 @@ constexpr int Rectangle::get_width()  const {
  * \brief Returns the height of this rectangle.
  * \return the height
  */
-constexpr int Rectangle::get_height() const {
+inline int Rectangle::get_height() const {
   return rect.h;
 }
 
@@ -221,7 +221,7 @@ constexpr int Rectangle::get_height() const {
  * \brief Returns the size of this rectangle.
  * \return the size
  */
-constexpr Size Rectangle::get_size() const {
+inline Size Rectangle::get_size() const {
   return { get_width(), get_height() };
 }
 
@@ -229,7 +229,7 @@ constexpr Size Rectangle::get_size() const {
  * \brief Returns whether this rectangle is flat.
  * \return true if the width or the height is 0.
  */
-constexpr bool Rectangle::is_flat() const {
+inline bool Rectangle::is_flat() const {
   return get_width() == 0 || get_height() == 0;
 }
 
@@ -374,7 +374,7 @@ inline void Rectangle::add_xy(const Point& dxy) {
  * \param y y coordinate of the point
  * \return true if the point is in this rectangle
  */
-constexpr bool Rectangle::contains(int x, int y) const {
+inline bool Rectangle::contains(int x, int y) const {
   return x >= get_x() && x < get_x() + get_width()
       && y >= get_y() && y < get_y() + get_height();
 }
@@ -384,7 +384,7 @@ constexpr bool Rectangle::contains(int x, int y) const {
  * \param point point that may be in this rectangle
  * \return true if \a point is in this rectangle
  */
-constexpr bool Rectangle::contains(const Point& point) const {
+inline bool Rectangle::contains(const Point& point) const {
   return contains(point.x, point.y);
 }
 
@@ -393,7 +393,7 @@ constexpr bool Rectangle::contains(const Point& point) const {
  * \param other another rectangle
  * \return true if the specified rectangle is inside this rectangle
  */
-constexpr bool Rectangle::contains(const Rectangle& other) const {
+inline bool Rectangle::contains(const Rectangle& other) const {
   return contains(other.get_x(), other.get_y())
       && contains(other.get_x() + other.get_width() - 1, other.get_y() + other.get_height() - 1);
 }
@@ -520,7 +520,7 @@ inline Rectangle& Rectangle::operator|=(const Rectangle& other) {
  * \param rhs second rectangle
  * \return true if both rectangles have the same coordinates and size
  */
-constexpr bool operator==(const Rectangle& lhs, const Rectangle& rhs) {
+inline bool operator==(const Rectangle& lhs, const Rectangle& rhs) {
   return lhs.get_xy() == rhs.get_xy()
       && lhs.get_size() == rhs.get_size();
 }
@@ -531,7 +531,7 @@ constexpr bool operator==(const Rectangle& lhs, const Rectangle& rhs) {
  * \param rhs second rectangle
  * \return true if the rectangles are not equal
  */
-constexpr bool operator!=(const Rectangle& lhs, const Rectangle& rhs) {
+inline bool operator!=(const Rectangle& lhs, const Rectangle& rhs) {
   return !(rhs == lhs);
 }
 


### PR DESCRIPTION
I tried to compile Solarus with MSVC 2015 RTM (using only the C++ build tools, not the whole Visual Studio). I still have to get past the linker stage, but I still managed to get everything that comes before to work. Here are the few changes:
* Change the order of `SOLARUS_API [[noreturn]]`.
* Tweak `Rectangle`'s constructors to bypass a bug in `constexpr`.
* Remove `contexpr` from every other `Rectangle` function. That one was too big to be bypassed.