### PR TITLE
Fix some cmake code

### DIFF
--- a/cmake/AddInstallTargets.cmake
+++ b/cmake/AddInstallTargets.cmake
@@ -3,7 +3,7 @@ if(CMAKE_LIBRARY_ARCHITECTURE)
   # Handle standard multi-architecture library directory names like x86_64-linux-gnu
   set(SOLARUS_LIBRARY_DIRECTORY_NAME "lib/${CMAKE_LIBRARY_ARCHITECTURE}")
 else()
-  set(SOLARUS_LIBRARY_DIRECTORY_NAME "lib")
+  set(SOLARUS_LIBRARY_DIRECTORY_NAME "lib${LIB_SUFFIX}")
 endif()
 
 set(SOLARUS_LIBRARY_INSTALL_DESTINATION "${SOLARUS_LIBRARY_DIRECTORY_NAME}" CACHE PATH "Library install destination")

--- a/cmake/modules/FindLuaJit.cmake
+++ b/cmake/modules/FindLuaJit.cmake
@@ -10,7 +10,7 @@
 FIND_PATH(LUA_INCLUDE_DIR luajit.h
   HINTS
   $ENV{LUA_DIR}
-  PATH_SUFFIXES include/luajit-2.0 include
+  PATH_SUFFIXES include/luajit-2.0 include/luajit-5_1-2.0 include
   PATHS
   ~/Library/Frameworks
   /Library/Frameworks


### PR DESCRIPTION
This will fix some cmake code:
 1. Install library file into lib64 if libsuffix is defined (a common practise)
 2. Detect luajit also if it was installed in directory with version suffix e.g. luajit-5_1-2.0
This is needed e.g. on openSUSE Linux (where directories are suffixed with version to allow installation of multiple versions at the same time)