### PR TITLE
Use constructor initialization list (CppCheck 1.71).

### DIFF
--- a/src/hero/ForcedWalkingState.cpp
+++ b/src/hero/ForcedWalkingState.cpp
@@ -1,16 +1,16 @@
 /*
  * Copyright (C) 2006-2015 Christopho, Solarus - http://www.solarus-games.org
- * 
+ *
  * Solarus is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Solarus is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -36,11 +36,11 @@ Hero::ForcedWalkingState::ForcedWalkingState(
     bool loop,
     bool ignore_obstacles):
 
-  BaseState(hero, "forced walking") {
-
-  this->movement = std::make_shared<PathMovement>(
+  BaseState(hero, "forced walking"),
+  movement(std::make_shared<PathMovement>(
       path, hero.get_walking_speed(), loop, ignore_obstacles, false
-  );
+  )) {
+
 }
 
 /**


### PR DESCRIPTION
I recently updated CppCheck to the version 1.71 and ran it on Solarus as usual. Not much new things but it managed to find a constructor that could use more constructor initialization list in `ForcedWalkingState`.