### PR TITLE
Remove unused variables (CppCheck 1.72)

### DIFF
--- a/src/entities/CustomEntity.cpp
+++ b/src/entities/CustomEntity.cpp
@@ -1161,7 +1161,6 @@ void CustomEntity::update_ground_observer() {
 
   // If there is no on_ground_below_changed() event, don't bother
   // determine the ground below.
-  static const std::string field_name = "on_ground_below_changed";
   bool ground_observer = get_lua_context()->userdata_has_field(
       *this, "field_name"
   );

--- a/src/entities/Entities.cpp
+++ b/src/entities/Entities.cpp
@@ -1273,9 +1273,6 @@ void Entities::notify_entity_bounding_box_changed(Entity& entity) {
  */
 bool Entities::overlaps_raised_blocks(int layer, const Rectangle& rectangle) {
 
-  std::set<std::shared_ptr<CrystalBlock>> blocks =
-      get_entities_by_type<CrystalBlock>(layer);
-
   EntityVector entities_nearby;
   get_entities_in_rectangle(rectangle, entities_nearby);
   for (const EntityPtr& entity : entities_nearby) {

--- a/src/entities/TilesetData.cpp
+++ b/src/entities/TilesetData.cpp
@@ -474,7 +474,6 @@ bool TilesetData::import_from_lua(lua_State* l) {
  */
 bool TilesetData::export_to_lua(std::ostream& out) const {
 
-  std::string last_pattern_id;
   // Background color.
   uint8_t r, g, b, a;
   background_color.get_components(r, g, b, a);
@@ -490,7 +489,6 @@ bool TilesetData::export_to_lua(std::ostream& out) const {
   for (const auto kvp : patterns) {
     const std::string& id = kvp.first;
     const TilePatternData& pattern = kvp.second;
-    last_pattern_id = id;
 
     const Rectangle& first_frame = pattern.get_frame();
     int width = first_frame.get_width();

--- a/src/lua/MainApi.cpp
+++ b/src/lua/MainApi.cpp
@@ -428,9 +428,8 @@ void LuaContext::main_on_draw(const SurfacePtr& dst_surface) {
  */
 bool LuaContext::main_on_input(const InputEvent& event) {
 
-  bool handled = false;
   push_main(l);
-  handled = on_input(event);
+  bool handled = on_input(event);
   if (!handled) {
     handled = menus_on_input(-1, event);
   }


### PR DESCRIPTION
New versions of CppCheck, new warnings: remove three unused variables in miscellaneous files, and also declare and initialize a variable later because its original value was always overwritten before being used.