### PR TITLE
Fix HAVE_MKSTEMP macro

### DIFF
--- a/cmake/AddConfigurationHeader.cmake
+++ b/cmake/AddConfigurationHeader.cmake
@@ -1,9 +1,16 @@
 # Generate config.h with useful configuration info.
 include(CheckFunctionExists)
-check_function_exists(mkstemp HAVE_MKSTEMP)
+check_function_exists(mkstemp MKSTEMP_FUNCTION_EXIST)
+
+include(CheckCxxSymbolExists)
+check_cxx_symbol_exists(mkstemp "cstdlib" MKSTEMP_SYMBOL_EXIST)
 
 include(CheckIncludeFiles)
 check_include_files(unistd.h HAVE_UNISTD_H)
+
+if(MKSTEMP_FUNCTION_EXIST AND MKSTEMP_SYMBOL_EXIST)
+	set(HAVE_MKSTEMP)
+endif()
 
 configure_file("${CMAKE_SOURCE_DIR}/include/solarus/config.h.in" "${CMAKE_BINARY_DIR}/include/solarus/config.h")
 

--- a/cmake/AddConfigurationHeader.cmake
+++ b/cmake/AddConfigurationHeader.cmake
@@ -2,15 +2,16 @@
 include(CheckFunctionExists)
 check_function_exists(mkstemp MKSTEMP_FUNCTION_EXIST)
 
-include(CheckCxxSymbolExists)
+include(CheckCXXSymbolExists)
 check_cxx_symbol_exists(mkstemp "cstdlib" MKSTEMP_SYMBOL_EXIST)
-
-include(CheckIncludeFiles)
-check_include_files(unistd.h HAVE_UNISTD_H)
 
 if(MKSTEMP_FUNCTION_EXIST AND MKSTEMP_SYMBOL_EXIST)
 	set(HAVE_MKSTEMP)
 endif()
+
+include(CheckIncludeFiles)
+check_include_files(unistd.h HAVE_UNISTD_H)
+
 
 configure_file("${CMAKE_SOURCE_DIR}/include/solarus/config.h.in" "${CMAKE_BINARY_DIR}/include/solarus/config.h")
 


### PR DESCRIPTION
I changed the cmake config that checked for mkstemp to be more robust. On my system the HAVE_MKSTEMP macro was true because I had Matlab installed, but the function didn't work with my Cygwin MinGW setup.

Now it checks both for linkability (CheckFunctionExists) and presence in the header files (CheckCxxSymbolExists). If both are true then HAVE_MKSTEMP is considered to be true.

Travis build failed probably because cmake is older than 2.8.6.