### PR TITLE
Add cursor visibility functions to the Lua API

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -62,6 +62,7 @@ Changes that introduce incompatibilities:
 * Fix entity:set_enabled(true) delayed while it blocks the hero (#817).
 * Fix brandished treasure sprite and shop treasure sprite not animated (#790).
 * movement:get/set_initial_angle() now use degrees (#721).
+* Add ability to hide mouse cursor (#891).
 
 Changes that do not introduce incompatibilities:
 

--- a/include/solarus/lowlevel/Video.h
+++ b/include/solarus/lowlevel/Video.h
@@ -70,6 +70,9 @@ class Video {
     static bool is_fullscreen();
     static void set_fullscreen(bool fullscreen);
 
+    static bool is_cursor_visible();
+    static void set_cursor_visible(bool cursor_visible);
+
     static std::string get_window_title();
     static void set_window_title(const std::string& window_title);
 

--- a/include/solarus/lua/LuaContext.h
+++ b/include/solarus/lua/LuaContext.h
@@ -478,6 +478,8 @@ class LuaContext {
       video_api_get_modes,
       video_api_is_fullscreen,
       video_api_set_fullscreen,
+      video_api_is_cursor_visible,
+      video_api_set_cursor_visible,
       video_api_get_quest_size,
       video_api_get_window_size,
       video_api_set_window_size,

--- a/src/lowlevel/Video.cpp
+++ b/src/lowlevel/Video.cpp
@@ -45,6 +45,7 @@ SDL_PixelFormat* pixel_format = nullptr;  /**< The pixel color format to use. */
 std::string rendering_driver_name;        /**< The name of the rendering driver. */
 bool disable_window = false;              /**< Indicates that no window is displayed (used for unit tests). */
 bool fullscreen_window = false;           /**< True if the window is in fullscreen. */
+bool visible_cursor = true;               /**< True if the mouse cursor is visible. */
 bool rendertarget_supported = false;      /**< True if rendering on texture is supported. */
 bool shaders_enabled = false;             /**< True if shaded modes support is enabled. */
 bool acceleration_enabled = false;        /**< \c true if 2D GPU acceleration is available and enabled. */
@@ -457,6 +458,26 @@ void Video::set_fullscreen(bool fullscreen) {
 }
 
 /**
+ * \brief Returns whether the mouse cursor is currently visible.
+ * \return true if the mouse cursor is currently visible.
+ */
+bool Video::is_cursor_visible() {
+  return visible_cursor;
+}
+
+/**
+ * \brief Sets the mouse cursor to visible or invisible.
+ * \param cursor_visible true to make the cursor visible.
+ */
+void Video::set_cursor_visible(bool cursor_visible) {
+
+  visible_cursor = cursor_visible;
+  Debug::check_assertion(video_mode != nullptr, "No video mode");
+  set_video_mode(*video_mode, is_fullscreen());
+  Logger::info(std::string("Cursor visible: ") + (cursor_visible ? "yes" : "no"));
+}
+
+/**
  * \brief Sets the default video mode.
  */
 void Video::set_default_video_mode() {
@@ -529,16 +550,13 @@ bool Video::set_video_mode(const VideoMode& mode, bool fullscreen) {
     return false;
   }
 
-  int show_cursor;
   Uint32 fullscreen_flag;
   if (fullscreen) {
     fullscreen_flag = SDL_WINDOW_FULLSCREEN_DESKTOP;
-    show_cursor = SDL_DISABLE;
     window_size = get_window_size();  // Store the window size before fullscreen.
   }
   else {
     fullscreen_flag = 0;
-    show_cursor = SDL_ENABLE;
   }
 
   video_mode = &mode;
@@ -565,7 +583,7 @@ bool Video::set_video_mode(const VideoMode& mode, bool fullscreen) {
         main_renderer,
         render_size.width,
         render_size.height);
-    SDL_ShowCursor(show_cursor);
+    SDL_ShowCursor(visible_cursor);
 
     if (mode_changed) {
       reset_window_size();

--- a/src/lua/VideoApi.cpp
+++ b/src/lua/VideoApi.cpp
@@ -43,6 +43,8 @@ void LuaContext::register_video_module() {
       { "get_modes", video_api_get_modes },
       { "is_fullscreen", video_api_is_fullscreen },
       { "set_fullscreen", video_api_set_fullscreen },
+      { "is_cursor_visible", video_api_is_cursor_visible },
+      { "set_cursor_visible", video_api_set_cursor_visible },
       { "get_quest_size", video_api_get_quest_size },
       { "get_window_size", video_api_get_window_size },
       { "set_window_size", video_api_set_window_size },
@@ -199,6 +201,37 @@ int LuaContext::video_api_set_fullscreen(lua_State *l) {
     bool fullscreen = LuaTools::opt_boolean(l, 1, true);
 
     Video::set_fullscreen(fullscreen);
+
+    return 0;
+  });
+}
+
+/**
+ * \brief Implementation of sol.video.is_cursor_visible().
+ * \param l the Lua context that is calling this function
+ * \return number of values to return to Lua
+ */
+int LuaContext::video_api_is_cursor_visible(lua_State *l) {
+
+  return LuaTools::exception_boundary_handle(l, [&] {
+    bool visible_cursor = Video::is_cursor_visible();
+
+    lua_pushboolean(l, visible_cursor);
+    return 1;
+  });
+}
+
+/**
+ * \brief Implementation of sol.video.set_fullscreen().
+ * \param l the Lua context that is calling this function
+ * \return number of values to return to Lua
+ */
+int LuaContext::video_api_set_cursor_visible(lua_State *l) {
+
+  return LuaTools::exception_boundary_handle(l, [&] {
+    bool visible_cursor = LuaTools::opt_boolean(l, 1, true);
+
+    Video::set_cursor_visible(visible_cursor);
 
     return 0;
   });


### PR DESCRIPTION
Implement the required functionality to poll and manipulate cursor visibility.

Add sol.video.is_cursor_visible() and 
sol.video.set_cursor_visible([cursor_visible]). The former corresponds to
SDL_ShowCursor(-1). The latter corresponds to SDL_ShowCursor(1) when applied
to true, and SDL_ShowCursor(0) when applied to false.

Signed-off-by: Alexander Berntsen <alexander@plaimi.net>