### PR TITLE
Set Solarus Settings to System Scope.

### DIFF
--- a/gui/src/settings.cpp
+++ b/gui/src/settings.cpp
@@ -25,7 +25,7 @@ namespace SolarusGui {
  * @brief Creates a Solarus settings object.
  */
 Settings::Settings() :
-  QSettings() {
+  QSettings(QSettings::SystemScope, "solarus", "solarus") {
 
 }
 


### PR DESCRIPTION
Overrides QSettings constructor call in Settings class to use
QSettings:SystemScope. Had to hardcode application and organization name to
QSettings constructor.

Closes #948.