### PR TITLE
iOS port

### DIFF
--- a/src/lowlevel/QuestFiles.cpp
+++ b/src/lowlevel/QuestFiles.cpp
@@ -480,7 +480,7 @@ SOLARUS_API std::string get_full_quest_write_dir() {
 SOLARUS_API std::string get_base_write_dir() {
 
 #if defined(SOLARUS_OSX) || defined(SOLARUS_IOS)
-  return std::string(get_user_application_support_directory());
+  return get_user_application_support_directory();
 #else
   return std::string(PHYSFS_getUserDir());
 #endif

--- a/src/lowlevel/apple/AppleInterface.mm
+++ b/src/lowlevel/apple/AppleInterface.mm
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License along
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+#include "solarus/lowlevel/Debug.h"
 #include "solarus/lowlevel/apple/AppleInterface.h"
 
 #if defined(SOLARUS_OSX) || defined(SOLARUS_IOS)
@@ -27,29 +28,29 @@
 
 
 /**
- * @brief Return "~/Library/Application Support" or equivalent from the official
- * way, which is available in OSX 10.6+ and iOS 4.0+.
+ * @brief Create and return the Application Support folder from the User Domain
+ * which doesn't exist by default in the iOS sandboxed environment.
  *
- * Return an OSX 10.0+ and iOS 1.0+ (not compatible with Iphone Simulator)
- * hardcoded equivalent workaround if the build configuration is set for a
- * lower minimum version.
  * @return The Application Support folder from the User Domain.
  */
 std::string get_user_application_support_directory()
 {
   @autoreleasepool {
 
-#if defined(SOLARUS_OSX) && __MAC_OS_X_VERSION_MIN_REQUIRED  >= MAC_OS_X_VERSION_10_6 \
- || defined(SOLARUS_IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
-    return [[[[[NSFileManager defaultManager]
-               URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask]
-              objectAtIndex:0]
-             path]
-            UTF8String];
-#else
-    return [[NSHomeDirectory() stringByAppendingPathComponent:@"Library/Application Support"]
-            UTF8String];
-#endif
+    NSString *appSupportDirectory = [NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES)
+        objectAtIndex:0];
+
+    // Create the Application Support folder if it doesn't exist yet.
+    if (![[NSFileManager defaultManager] fileExistsAtPath:appSupportDirectory isDirectory:NULL]) {
+
+      NSError *error = nil;
+      if (![[NSFileManager defaultManager]
+            createDirectoryAtPath:appSupportDirectory withIntermediateDirectories:YES attributes:nil error:&error]) {
+        Solarus::Debug::error("Cannot create " + std::string([appSupportDirectory UTF8String]));
+      }
+    }
+
+    return [appSupportDirectory UTF8String];
   }
 }
 

--- a/src/lowlevel/apple/AppleInterface.mm
+++ b/src/lowlevel/apple/AppleInterface.mm
@@ -37,15 +37,21 @@ std::string get_user_application_support_directory()
 {
   @autoreleasepool {
 
-    NSString *app_support_directory = [NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES)
+    NSString* app_support_directory = [
+        NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES)
         objectAtIndex:0];
 
     // Create the Application Support folder if it doesn't exist yet.
-    if (![[NSFileManager defaultManager] fileExistsAtPath:app_support_directory isDirectory:NULL]) {
+    if (![[NSFileManager defaultManager]
+        fileExistsAtPath:app_support_directory
+        isDirectory:NULL]) {
 
-      NSError *error = nil;
+      NSError* error = nil;
       if (![[NSFileManager defaultManager]
-            createDirectoryAtPath:app_support_directory withIntermediateDirectories:YES attributes:nil error:&error]) {
+          createDirectoryAtPath:app_support_directory
+          withIntermediateDirectories:YES
+          attributes:nil
+          error:&error]) {
         Solarus::Debug::error("Cannot create " + std::string([app_support_directory UTF8String]));
       }
     }

--- a/src/lowlevel/apple/AppleInterface.mm
+++ b/src/lowlevel/apple/AppleInterface.mm
@@ -37,20 +37,20 @@ std::string get_user_application_support_directory()
 {
   @autoreleasepool {
 
-    NSString *appSupportDirectory = [NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES)
+    NSString *app_support_directory = [NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES)
         objectAtIndex:0];
 
     // Create the Application Support folder if it doesn't exist yet.
-    if (![[NSFileManager defaultManager] fileExistsAtPath:appSupportDirectory isDirectory:NULL]) {
+    if (![[NSFileManager defaultManager] fileExistsAtPath:app_support_directory isDirectory:NULL]) {
 
       NSError *error = nil;
       if (![[NSFileManager defaultManager]
-            createDirectoryAtPath:appSupportDirectory withIntermediateDirectories:YES attributes:nil error:&error]) {
-        Solarus::Debug::error("Cannot create " + std::string([appSupportDirectory UTF8String]));
+            createDirectoryAtPath:app_support_directory withIntermediateDirectories:YES attributes:nil error:&error]) {
+        Solarus::Debug::error("Cannot create " + std::string([app_support_directory UTF8String]));
       }
     }
 
-    return [appSupportDirectory UTF8String];
+    return [app_support_directory UTF8String];
   }
 }
 


### PR DESCRIPTION
iOS environment is sandboxed and the application support folder doesn't exist by default, so we need to create it if it doesn't exist.
All other issues should be handled by the XCode project, so this complete the iOS port.